### PR TITLE
MYCE-105 feat: 역할 기반 페이지 접근 제어 및 동적 UI 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,10 @@ import ScrollToTop from "./components/rollback/ScrollToTop";
 import { AuthProvider } from "./contexts/AuthContext";
 import theme from "./theme";
 
+// 보호 라우트 컴포넌트 임포트
+import SellerProtectedRoute from "./components/SellerProtectedRoute";
+import AdminProtectedRoute from "./components/AdminProtectedRoute";
+
 // 페이지 컴포넌트들
 const HomePage = lazy(() => import("./pages/HomePage"));
 const ProductsPage = lazy(() => import("./pages/products/Lists"));
@@ -69,8 +73,26 @@ const App: FC = () => {
               <Route path="/reviews" element={<ReviewsPage />} />
               <Route path="/report-manage" element={<ReportManagePage />} />
               <Route path="/user-manage" element={<UserManagePage />} />
-              <Route path="/admin-dashboard" element={<AdminDashboardPage />} />
-              <Route path="/stats-dashboard" element={<StatsDashboardPage />} />
+              <Route
+                path="/admin-dashboard"
+                element={
+                  <AdminProtectedRoute redirectPath="/">
+                    {" "}
+                    {/* admin만 허용, 아니면 메인으로 리디렉션 */}
+                    <AdminDashboardPage />
+                  </AdminProtectedRoute>
+                }
+              />
+              <Route
+                path="/stats-dashboard" // 통계 대시보드 경로
+                element={
+                  <AdminProtectedRoute redirectPath="/">
+                    {" "}
+                    {/* admin만 허용, 아니면 메인으로 리디렉션 */}
+                    <StatsDashboardPage />
+                  </AdminProtectedRoute>
+                }
+              />
               <Route path="/store-home" element={<StoreHomePage />} />
               <Route path="/cart" element={<CartPage />} />
               <Route path="/orders" element={<OrdersPage />} />
@@ -93,7 +115,17 @@ const App: FC = () => {
               <Route path="/events/edit/:id" element={<EventEditPage />} />
               <Route path="/events/result" element={<EventResultPage />} />
               <Route path="/become-seller" element={<BecomeSellerPage />} />
-              <Route path="/seller-mypage" element={<SellerMyPage />} />
+              <Route
+                path="/seller-mypage"
+                element={
+                  <SellerProtectedRoute
+                    allowedUserType="seller"
+                    redirectPath="/"
+                  >
+                    <SellerMyPage />
+                  </SellerProtectedRoute>
+                }
+              />
             </Route>
 
             {/* Layout 없이 보여야 하는 페이지들 */}

--- a/src/components/AdminProtectedRoute.tsx
+++ b/src/components/AdminProtectedRoute.tsx
@@ -1,0 +1,33 @@
+// src/components/AdminProtectedRoute.tsx
+import React from "react";
+import { Navigate, Outlet } from "react-router-dom";
+import { useAuth } from "../contexts/AuthContext";
+
+interface AdminProtectedRouteProps {
+  children?: React.ReactNode;
+  redirectPath?: string; // 권한 없을 시 리디렉션될 경로
+}
+
+const AdminProtectedRoute: React.FC<AdminProtectedRouteProps> = ({
+  children,
+  redirectPath = "/", // 기본 리디렉션 경로를 메인 페이지로 설정
+}) => {
+  const { user } = useAuth(); // AuthContext에서 user 정보 가져오기
+
+  // 1. 로그인 자체가 안 되어 있는 경우
+  if (!user) {
+    return <Navigate to="/login" replace />; // 로그인 페이지로 리디렉션
+  }
+
+  // 2. 로그인되어 있지만 userType이 'admin'이 아닌 경우
+  // user 또는 seller가 admin 페이지에 접근하려 할 때
+  if (user.userType !== "admin") {
+    // console.log(`Access Denied: User type is ${user.userType}, but 'admin' is required.`);
+    return <Navigate to={redirectPath} replace />; // 메인 페이지로 리디렉션
+  }
+
+  // 3. userType이 'admin'인 경우
+  return children ? <>{children}</> : <Outlet />;
+};
+
+export default AdminProtectedRoute;

--- a/src/components/SellerProtectedRoute.tsx
+++ b/src/components/SellerProtectedRoute.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { Navigate, Outlet } from "react-router-dom";
+import { useAuth } from "../contexts/AuthContext";
+
+interface SellerProtectedRouteProps {
+  children?: React.ReactNode; // 렌더링할 자식 컴포넌트 (선택 사항, Outlet과 함께 사용)
+  allowedUserType: "user" | "admin" | "seller"; // 이 경로에 허용되는 userType
+  redirectPath?: string; // 권한 없을 시 리디렉션될 경로
+}
+
+const SellerProtectedRoute: React.FC<SellerProtectedRouteProps> = ({
+  children,
+  allowedUserType,
+  redirectPath = "/", // 기본 리디렉션 경로를 메인 페이지로 설정
+}) => {
+  const { user } = useAuth(); // AuthContext에서 user 정보 가져오기
+
+  // 1. 로그인 자체가 안 되어 있는 경우
+  if (!user) {
+    return <Navigate to="/login" replace />; // 로그인 페이지로 리디렉션 (로그인 후 다시 시도하게)
+  }
+
+  // 2. 로그인되어 있지만 userType이 허용된 타입이 아닌 경우
+  // admin이 seller 페이지에 접근하려 할 때, user가 seller 페이지에 접근하려 할 때
+  if (user.userType !== allowedUserType) {
+    // console.log(`Access Denied: User type is ${user.userType}, but ${allowedUserType} is required.`);
+    return <Navigate to={redirectPath} replace />; // 메인 페이지로 리디렉션
+  }
+
+  // 3. userType이 허용된 타입인 경우 (seller)
+  // children이 있으면 children을 렌더링하고, 없으면 Outlet (중첩 라우트 사용 시)
+  return children ? <>{children}</> : <Outlet />;
+};
+
+export default SellerProtectedRoute;


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약해주세요 -->
사용자 역할(User, Admin, Seller)에 따른 페이지 접근 권한을 제어하고, 공통 UI/로직을 구현했습니다.

**Type**
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?
<!-- 구현한 기능이나 수정한 내용을 설명해주세요 -->

역할 기반 페이지 접근 제어(SellerProtectedRoute, AdminProtectedRoute) 구현:

seller-mypage 경로에 seller 역할만 접근 가능하도록 보호했습니다.

admin-dashboard 및 stats-dashboard 경로에 admin 역할만 접근 가능하도록 보호했습니다.

각 보호된 경로에 대해 권한이 없는 사용자는 메인 페이지로 리디렉션되도록 처리했습니다.

### 왜 필요했나요?
<!-- 이 작업이 필요한 이유나 해결하려는 문제를 설명해주세요 -->

보안 및 사용자 경험 향상: 사용자 역할에 따라 접근 가능한 페이지를 제한하여 민감한 정보 및 기능을 보호하고, 각 역할에 맞는 최적화된 UI를 제공하여 사용자 경험을 향상시키기 위함입니다.

---

## 🔧 How (구현 방법)
### 주요 변경사항
 src/components/SellerProtectedRoute.tsx 신규 추가: seller 역할만 허용하는 라우트 보호 컴포넌트

src/components/AdminProtectedRoute.tsx 신규 추가: admin 역할만 허용하는 라우트 보호 컴포넌트

App.tsx 또는 라우팅 파일 수정: /seller-mypage, /admin-dashboard, /stats-dashboard 경로에 각각 SellerProtectedRoute, AdminProtectedRoute 적용

### 기술적 접근
React Router Maps 및 Outlet: react-router-dom의 기능을 활용하여 권한 없는 접근 시 특정 경로로 리디렉션 처리.

React Context API (AuthContext): 사용자 로그인 상태 및 userType을 전역적으로 관리하여 컴포넌트 간 데이터 공유.

---

## 🧪 Testing
### 테스트 방법
<!-- 어떻게 테스트했는지 설명해주세요 -->

일반 사용자 계정으로 로그인 후 seller-mypage, admin-dashboard, stats-dashboard 접근 시 메인 페이지로 리디렉션되는지 확인.

판매자 계정으로 로그인 후 seller-mypage에 정상 접근되고, 사이드바/헤더에 판매자 전용 메뉴가 표시되는지 확인.

관리자 계정으로 로그인 후 admin-dashboard 및 stats-dashboard에 정상 접근되는지 확인.

각 역할별로 올바른 메뉴만 표시되는지 헤더 및 사이드바 확인.

### 확인 사항
- [x] 기능 정상 동작 확인
- [x] 기존 기능 영향 없음
- [x] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 관련 이슈: 없음
- 지라 백로그: [https://sesac-springboot.atlassian.net/browse/MYCE-105](url)
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->

---

## ✅ Checklist
- [x] 코드 리뷰 준비 완료
- [x] 테스트 완료
- [x] 불필요한 로그 제거
