### PR TITLE
MYCE-206 feat: 헤더 카테고리 버튼 모달 UI 추가

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -4,6 +4,7 @@ import styled, { keyframes } from "styled-components";
 import { Link, useNavigate } from "react-router-dom";
 import { FormEvent } from "react";
 import { useAuth } from "../../contexts/AuthContext";
+import CategoryModal from "../modal/CategoryModal";
 
 // 애니메이션 정의
 const slideDown = keyframes`
@@ -196,6 +197,55 @@ const NavLink = styled(Link)`
     &::before {
       left: 100%;
     }
+  }
+`;
+
+// 카테고리 버튼 스타일드 컴포넌트 (NavLink와 동일한 스타일)
+const CategoryButton = styled.button`
+  color: rgba(255, 255, 255, 0.9);
+  background: transparent;
+  border: none;
+  font-size: 16px;
+  font-weight: 500;
+  padding: 8px 16px;
+  border-radius: 12px;
+  transition: all 0.3s ease;
+  position: relative;
+  overflow: hidden;
+  z-index: 2;
+  white-space: nowrap;
+  cursor: pointer;
+  font-family: inherit;
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      rgba(249, 115, 22, 0.3),
+      transparent
+    );
+    transition: left 0.5s;
+  }
+
+  &:hover {
+    background: rgba(249, 115, 22, 0.2);
+    color: white;
+    transform: translateY(-2px);
+
+    &::before {
+      left: 100%;
+    }
+  }
+
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(249, 115, 22, 0.4);
   }
 `;
 
@@ -759,6 +809,7 @@ const Header: FC<HeaderProps> = ({ onMenuClick }) => {
   const navigate = useNavigate();
   const [search, setSearch] = useState("");
   const [showUserMenu, setShowUserMenu] = useState(false);
+  const [isCategoryModalOpen, setIsCategoryModalOpen] = useState(false);
   const { user, logout } = useAuth();
   const userMenuRef = useRef<HTMLDivElement>(null);
 
@@ -791,6 +842,17 @@ const Header: FC<HeaderProps> = ({ onMenuClick }) => {
     navigate("/");
   };
 
+  // 카테고리 모달 열기 핸들러
+  const handleCategoryClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setIsCategoryModalOpen(true);
+  };
+
+  // 카테고리 모달 닫기 핸들러
+  const closeCategoryModal = () => {
+    setIsCategoryModalOpen(false);
+  };
+
   const getInitials = (name: string) => {
     if (!name || name.trim() === "") return "?";
     return name
@@ -812,10 +874,10 @@ const Header: FC<HeaderProps> = ({ onMenuClick }) => {
           <i className="fas fa-shopping-bag" style={{ marginRight: "8px" }}></i>
           상품
         </NavLink>
-        <NavLink to="/categories">
+        <CategoryButton onClick={handleCategoryClick} type="button">
           <i className="fas fa-th-large" style={{ marginRight: "8px" }}></i>
           카테고리
-        </NavLink>
+        </CategoryButton>
         <NavLink to="/event-list">
           <i className="fas fa-gift" style={{ marginRight: "8px" }}></i>
           이벤트
@@ -896,6 +958,10 @@ const Header: FC<HeaderProps> = ({ onMenuClick }) => {
           </LoginButton>
         )}
       </UserSection>
+      <CategoryModal
+        isOpen={isCategoryModalOpen}
+        onClose={closeCategoryModal}
+      />
     </HeaderContainer>
   );
 };


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
Header 네비게이션에 CategoryModal UI를 연결하여 카테고리 탐색 기능 추가

**Type**
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore

---

## 🎯 What & Why

### 무엇을 했나요?
- Header 컴포넌트의 카테고리 버튼에 CategoryModal 연결
- 카테고리 버튼 클릭 시 모달이 열리도록 이벤트 핸들러 구현
- 모달 상태 관리를 위한 state 및 핸들러 함수 추가

### 왜 필요했나요?
- 사용자가 Header에서 바로 카테고리를 탐색할 수 있도록 UX 개선
- 기존 네비게이션 항목들과 일관성 있는 인터랙션 제공
- 모바일/데스크탑 모든 환경에서 카테고리 접근성 향상

---

## 🔧 How (구현 방법)

### 주요 변경사항
- `isCategoryModalOpen` state 추가하여 모달 열림/닫힘 상태 관리
- `handleCategoryClick` 함수로 카테고리 버튼 클릭 이벤트 처리
- `closeCategoryModal` 함수로 모달 닫기 기능 구현
- CategoryModal 컴포넌트를 Header 하단에 렌더링

### 기술적 접근
- 기존 CategoryModal 컴포넌트를 그대로 활용
- React useState hook을 사용한 모달 상태 관리
- 이벤트 핸들러를 통한 모달 제어
- NavLink와 동일한 스타일링을 적용한 CategoryButton 컴포넌트 사용

---

## 🧪 Testing

### 테스트 방법
- 데스크탑 환경에서 카테고리 버튼 클릭 시 모달 정상 표시 확인
- 모달 외부 클릭 또는 닫기 버튼으로 모달 닫힘 확인
- 기존 네비게이션 기능들과의 충돌 없음 확인
- 반응형 환경에서 정상 동작 확인

### 확인 사항
- [x] 기능 정상 동작 확인
- [x] 기존 기능 영향 없음
- [x] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 지라 백로그: MYCE-206

---

## 💬 Additional Notes
- CategoryModal 컴포넌트는 이미 구현되어 있어 단순히 연결만 진행
- 기존 Header의 스타일링과 애니메이션을 유지하면서 통합
- 모바일 환경에서는 햄버거 메뉴를 통해 카테고리에 접근 가능

---

## ✅ Checklist
- [x] 코드 리뷰 준비 완료
- [x] 테스트 완료
- [x] 불필요한 로그 제거