### PR TITLE
MYCE-93 : refactor/feed -  feedDetailPage.tsx, feedDetaolCard.page 리팩토링 

### DIFF
--- a/src/api/feedService.ts
+++ b/src/api/feedService.ts
@@ -41,10 +41,44 @@ export class FeedService {
       const response = await axiosInstance.get<ApiResponse<FeedPost>>(
         `/api/feeds/${feedId}`
       );
-      const apiResponse = response.data;
-      return apiResponse.data;
+      
+      // 백엔드 응답 구조에 따라 처리
+      if (response.data.success) {
+        return response.data.data;
+      } else {
+        throw new Error(response.data.message || '피드 조회에 실패했습니다.');
+      }
     } catch (error: any) {
       console.error('피드 상세 조회 실패:', error);
+      
+      // 백엔드 연결 실패시 더미 데이터 반환 (개발용)
+      if (error.code === 'NETWORK_ERROR' || error.response?.status >= 500) {
+        console.warn('백엔드 서버 연결 실패 - 더미 데이터 사용');
+        return {
+          id: feedId,
+          title: `피드 ${feedId}`,
+          content: '피드 내용입니다.',
+          feedType: 'DAILY',
+          likeCount: 0,
+          commentCount: 0,
+          participantVoteCount: 0,
+          user: {
+            id: 1,
+            nickname: '사용자',
+            level: 1,
+            profileImg: 'https://via.placeholder.com/60',
+          },
+          orderItem: {
+            id: 1,
+            productName: '상품명',
+            size: 250,
+          },
+          images: [],
+          hashtags: [],
+          createdAt: new Date().toISOString(),
+        };
+      }
+      
       throw error;
     }
   }

--- a/src/api/feedService.ts
+++ b/src/api/feedService.ts
@@ -15,18 +15,100 @@ import {
   CommentListParams,
 } from "../types/feed";
 
+// 백엔드 응답 타입 정의
+interface BackendFeedPost {
+  feedId: number;
+  title: string;
+  content: string;
+  instagramId?: string;
+  feedType: 'DAILY' | 'EVENT' | 'RANKING';
+  likeCount: number;
+  commentCount: number;
+  participantVoteCount: number;
+  userId: number;
+  userNickname: string;
+  userLevel?: number;
+  userProfileImg?: string;
+  userGender?: string;
+  userHeight?: number;
+  orderItemId: number;
+  productName: string;
+  productSize?: number;
+  eventId?: number;
+  eventTitle?: string;
+  eventDescription?: string;
+  eventStartDate?: string;
+  eventEndDate?: string;
+  hashtags?: any[];
+  images?: any[];
+  imageUrls?: string[];
+  isLiked?: boolean;
+  isVoted?: boolean;
+  createdAt: string;
+  updatedAt?: string;
+}
+
 export class FeedService {
   /**
    * 피드 목록을 조회합니다
    */
   static async getFeeds(params: FeedListParams = {}): Promise<FeedListResponse> {
     try {
-      const response = await axiosInstance.get<ApiResponse<FeedListResponse>>(
+      const response = await axiosInstance.get<ApiResponse<any>>(
         '/api/feeds',
         { params }
       );
       const apiResponse = response.data;
-      return apiResponse.data;
+      
+      // 백엔드 응답을 프론트엔드 타입에 맞게 변환
+      const transformedFeeds = apiResponse.data.content.map((backendFeed: BackendFeedPost) => ({
+        id: backendFeed.feedId,
+        title: backendFeed.title,
+        content: backendFeed.content,
+        instagramId: backendFeed.instagramId,
+        feedType: backendFeed.feedType,
+        likeCount: backendFeed.likeCount,
+        commentCount: backendFeed.commentCount,
+        participantVoteCount: backendFeed.participantVoteCount,
+        user: {
+          id: backendFeed.userId,
+          nickname: backendFeed.userNickname,
+          level: backendFeed.userLevel,
+          profileImg: backendFeed.userProfileImg,
+          gender: backendFeed.userGender,
+          height: backendFeed.userHeight,
+        },
+        orderItem: {
+          id: backendFeed.orderItemId,
+          productName: backendFeed.productName,
+          size: backendFeed.productSize,
+        },
+        event: backendFeed.eventId && backendFeed.eventTitle && backendFeed.eventStartDate && backendFeed.eventEndDate ? {
+          id: backendFeed.eventId,
+          title: backendFeed.eventTitle,
+          description: backendFeed.eventDescription,
+          startDate: backendFeed.eventStartDate,
+          endDate: backendFeed.eventEndDate,
+        } : undefined,
+        images: backendFeed.imageUrls?.map((url: string, index: number) => ({
+          id: index + 1,
+          imageUrl: url,
+          sortOrder: index,
+        })) || [],
+        hashtags: backendFeed.hashtags?.map((tag: string, index: number) => ({
+          id: index + 1,
+          tag: tag,
+        })) || [],
+        isLiked: backendFeed.isLiked,
+        isVoted: backendFeed.isVoted,
+        createdAt: backendFeed.createdAt,
+        updatedAt: backendFeed.updatedAt,
+      }));
+      
+      return {
+        ...apiResponse.data,
+        content: transformedFeeds,
+      };
     } catch (error: any) {
       console.error('피드 목록 조회 실패:', error);
       throw error;
@@ -38,46 +120,81 @@ export class FeedService {
    */
   static async getFeed(feedId: number): Promise<FeedPost> {
     try {
-      const response = await axiosInstance.get<ApiResponse<FeedPost>>(
-        `/api/feeds/${feedId}`
-      );
+      console.log(`FeedService.getFeed 호출 - feedId: ${feedId}`);
+      const url = `/api/feeds/${feedId}`;
+      console.log(`API 호출 URL: ${url}`);
+      
+      const response = await axiosInstance.get<ApiResponse<BackendFeedPost>>(url);
+      
+      console.log('API 응답 상태:', response.status);
+      console.log('API 응답 데이터:', response.data);
       
       // 백엔드 응답 구조에 따라 처리
       if (response.data.success) {
-        return response.data.data;
+        console.log('피드 조회 성공:', response.data.data);
+        const backendData: BackendFeedPost = response.data.data;
+        
+        // 백엔드 응답을 프론트엔드 타입에 맞게 변환
+        const feedPost: FeedPost = {
+          id: backendData.feedId,
+          title: backendData.title,
+          content: backendData.content,
+          instagramId: backendData.instagramId,
+          feedType: backendData.feedType,
+          likeCount: backendData.likeCount,
+          commentCount: backendData.commentCount,
+          participantVoteCount: backendData.participantVoteCount,
+          user: {
+            id: backendData.userId,
+            nickname: backendData.userNickname,
+            level: backendData.userLevel,
+            profileImg: backendData.userProfileImg,
+            gender: backendData.userGender,
+            height: backendData.userHeight,
+          },
+          orderItem: {
+            id: backendData.orderItemId,
+            productName: backendData.productName,
+            size: backendData.productSize,
+          },
+          event: backendData.eventId && backendData.eventTitle && backendData.eventStartDate && backendData.eventEndDate ? {
+            id: backendData.eventId,
+            title: backendData.eventTitle,
+            description: backendData.eventDescription,
+            startDate: backendData.eventStartDate,
+            endDate: backendData.eventEndDate,
+          } : undefined,
+          images: backendData.images?.map((img: any) => ({
+            id: img.imageId || img.id,
+            imageUrl: img.imageUrl,
+            sortOrder: img.sortOrder || 0,
+          })) || [],
+          hashtags: backendData.hashtags?.map((tag: any) => ({
+            id: tag.tagId || tag.id,
+            tag: tag.tag,
+          })) || [],
+          isLiked: backendData.isLiked,
+          isVoted: backendData.isVoted,
+          createdAt: backendData.createdAt,
+          updatedAt: backendData.updatedAt,
+        };
+        
+        console.log('변환된 피드 데이터:', feedPost);
+        return feedPost;
       } else {
+        console.log('API 응답 실패:', response.data.message);
         throw new Error(response.data.message || '피드 조회에 실패했습니다.');
       }
     } catch (error: any) {
       console.error('피드 상세 조회 실패:', error);
+      console.error('에러 상세:', {
+        message: error.message,
+        status: error.response?.status,
+        statusText: error.response?.statusText,
+        data: error.response?.data
+      });
       
-      // 백엔드 연결 실패시 더미 데이터 반환 (개발용)
-      if (error.code === 'NETWORK_ERROR' || error.response?.status >= 500) {
-        console.warn('백엔드 서버 연결 실패 - 더미 데이터 사용');
-        return {
-          id: feedId,
-          title: `피드 ${feedId}`,
-          content: '피드 내용입니다.',
-          feedType: 'DAILY',
-          likeCount: 0,
-          commentCount: 0,
-          participantVoteCount: 0,
-          user: {
-            id: 1,
-            nickname: '사용자',
-            level: 1,
-            profileImg: 'https://via.placeholder.com/60',
-          },
-          orderItem: {
-            id: 1,
-            productName: '상품명',
-            size: 250,
-          },
-          images: [],
-          hashtags: [],
-          createdAt: new Date().toISOString(),
-        };
-      }
+      // 백엔드 에러를 그대로 전파하여 실제 데이터베이스 오류를 확인할 수 있도록 함
       
       throw error;
     }

--- a/src/components/feed/FeedCard.tsx
+++ b/src/components/feed/FeedCard.tsx
@@ -3,15 +3,19 @@ import React from "react";
 interface FeedCardProps {
   feed: {
     id: number;
-    image: string;
+    images?: Array<{ imageUrl: string }>;
     title: string;
-    description: string;
-    author?: string;
-    date?: string;
-    likes?: number;
-    size?: number;
+    content: string;
+    user?: {
+      nickname: string;
+    };
+    createdAt?: string;
+    likeCount?: number;
+    orderItem?: {
+      size?: number;
+    };
     feedType?: string;
-    votes?: number;
+    participantVoteCount?: number;
   };
   onClick?: () => void;
   onVoteClick?: () => void;
@@ -21,31 +25,33 @@ interface FeedCardProps {
 }
 
 const FeedCard: React.FC<FeedCardProps> = ({ feed, onClick, onVoteClick, onLikeClick, liked, likes }) => {
+  const imageUrl = feed.images && feed.images.length > 0 ? feed.images[0].imageUrl : 'https://via.placeholder.com/300x400?text=No+Image';
+  
   return (
     <div className="border p-4 rounded-lg hover:shadow flex flex-col cursor-pointer" onClick={onClick}>
-      <img src={feed.image} alt={feed.title} className="aspect-[3/4] object-cover rounded" />
+      <img src={imageUrl} alt={feed.title} className="aspect-[3/4] object-cover rounded" />
       <h3 className="mt-2 text-gray-900 line-clamp-2 font-semibold">{feed.title}</h3>
-      <p className="text-gray-500 text-sm mb-2 line-clamp-2">{feed.description}</p>
-      {feed.size && (
-        <p className="text-gray-500 text-xs mb-1">신발 사이즈: {feed.size}mm</p>
+      <p className="text-gray-500 text-sm mb-2 line-clamp-2">{feed.content}</p>
+      {feed.orderItem?.size && (
+        <p className="text-gray-500 text-xs mb-1">신발 사이즈: {feed.orderItem.size}mm</p>
       )}
       <div className="flex justify-between items-center text-xs text-gray-400 mt-auto">
-        {feed.author && <span>{feed.author}</span>}
-        {feed.date && <span>{feed.date}</span>}
+        {feed.user?.nickname && <span>{feed.user.nickname}</span>}
+        {feed.createdAt && <span>{new Date(feed.createdAt).toLocaleDateString()}</span>}
         <button
           className="flex items-center gap-1 focus:outline-none"
           onClick={e => { e.stopPropagation(); onLikeClick && onLikeClick(); }}
           disabled={liked}
         >
-          <i className={`fas fa-heart ${liked ? 'text-red-500' : 'text-gray-300'}`}></i> {typeof likes === 'number' ? likes : feed.likes}
+          <i className={`fas fa-heart ${liked ? 'text-red-500' : 'text-gray-300'}`}></i> {typeof likes === 'number' ? likes : feed.likeCount}
         </button>
       </div>
-      {feed.feedType === 'event' && (
+      {feed.feedType === 'EVENT' && (
         <button
           className="mt-3 w-full bg-[#87CEEB] text-white py-2 rounded-lg font-medium hover:bg-blue-400 transition"
           onClick={e => { e.stopPropagation(); onVoteClick && onVoteClick(); }}
         >
-          <i className="fas fa-vote-yea mr-1"></i> 투표하기{typeof feed.votes === 'number' ? ` (${feed.votes})` : ''}
+          <i className="fas fa-vote-yea mr-1"></i> 투표하기{typeof feed.participantVoteCount === 'number' ? ` (${feed.participantVoteCount})` : ''}
         </button>
       )}
     </div>

--- a/src/components/feed/FeedDetailModal.tsx
+++ b/src/components/feed/FeedDetailModal.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import { FeedPost } from '../../types/feed';
 
 interface FeedDetailModalProps {
   open: boolean;
   onClose: () => void;
-  feed: any;
+  feed: FeedPost | null;
   comments: any[];
   showComments: boolean;
   onToggleComments: () => void;
@@ -48,6 +49,7 @@ const FeedDetailModal: React.FC<FeedDetailModalProps> = ({
   onCommentSubmit,
 }) => {
   if (!open || !feed) return null;
+  const heroImage = feed.images && feed.images.length > 0 ? feed.images[0].imageUrl : 'https://via.placeholder.com/600x800?text=No+Image';
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4">
       <div className="bg-white rounded-lg max-w-2xl w-full max-h-[90vh] overflow-y-auto relative">
@@ -61,22 +63,26 @@ const FeedDetailModal: React.FC<FeedDetailModalProps> = ({
         <div className="flex flex-col md:flex-row">
           {/* 이미지 */}
           <div className="md:w-1/2">
-            <img src={feed.images[0]} alt={feed.productName} className="w-full h-80 object-cover object-top rounded-l-lg" />
+            <img src={heroImage} alt={feed.title} className="w-full h-80 object-cover object-top rounded-l-lg" />
           </div>
           {/* 상세 정보 */}
           <div className="md:w-1/2 p-6">
             <div className="flex items-center mb-6">
-              <img src={feed.profileImg} alt={feed.username} className="w-12 h-12 rounded-full object-cover mr-3" />
+              <img src={feed.user?.profileImg || 'https://via.placeholder.com/60'} alt={feed.user?.nickname || '사용자'} className="w-12 h-12 rounded-full object-cover mr-3" />
               <div>
                 <div className="flex items-center">
-                  <h3 className="font-medium text-lg">{feed.username}</h3>
-                  <div className="ml-2 bg-[#87CEEB] text-white text-xs px-2 py-0.5 rounded-full flex items-center">
-                    <i className="fas fa-crown text-yellow-300 mr-1 text-xs"></i>
-                    <span>Lv.{feed.level}</span>
-                  </div>
+                  <h3 className="font-medium text-lg">{feed.user?.nickname || '사용자'}</h3>
+                  {feed.user?.level && (
+                    <div className="ml-2 bg-[#87CEEB] text-white text-xs px-2 py-0.5 rounded-full flex items-center">
+                      <i className="fas fa-crown text-yellow-300 mr-1 text-xs"></i>
+                      <span>Lv.{feed.user.level}</span>
+                    </div>
+                  )}
                 </div>
                 <div className="flex items-center text-sm text-gray-500 mt-1">
-                  <span>{feed.gender} · {feed.height}cm</span>
+                  {feed.user?.gender && feed.user?.height && (
+                    <span>{feed.user.gender} · {feed.user.height}cm</span>
+                  )}
                   {feed.instagramId && (
                     <a href={`https://instagram.com/${feed.instagramId}`} target="_blank" rel="noopener noreferrer" className="ml-3 text-[#87CEEB] hover:underline cursor-pointer">
                       <i className="fab fa-instagram mr-1"></i>
@@ -87,12 +93,14 @@ const FeedDetailModal: React.FC<FeedDetailModalProps> = ({
               </div>
             </div>
             <div className="mb-6">
-              <h2 className="text-xl font-bold mb-2">{feed.productName}</h2>
-              <p className="text-gray-600">신발 사이즈: {feed.size}mm</p>
+              <h2 className="text-xl font-bold mb-2">{feed.title}</h2>
+              {feed.orderItem && (
+                <p className="text-gray-600">신발 사이즈: {feed.orderItem.size}mm</p>
+              )}
             </div>
             <div className="mb-6">
               <h3 className="font-medium mb-2">상품 설명</h3>
-              <p className="text-gray-700 leading-relaxed">{feed.description}</p>
+              <p className="text-gray-700 leading-relaxed whitespace-pre-wrap">{feed.content}</p>
             </div>
             <div className="flex items-center justify-between border-t border-gray-200 pt-4">
               <div className="flex space-x-6">
@@ -102,14 +110,14 @@ const FeedDetailModal: React.FC<FeedDetailModalProps> = ({
                   disabled={liked}
                 >
                   <i className={`fas fa-heart mr-2 ${liked ? 'text-red-500' : ''}`}></i>
-                  <span>{feed.likes + (liked ? 1 : 0)}</span>
+                  <span>{feed.likeCount || 0}</span>
                 </button>
                 <button
                   className="flex items-center text-gray-500 hover:text-[#87CEEB] cursor-pointer"
                   onClick={onToggleComments}
                 >
                   <i className="fas fa-comment mr-2"></i>
-                  <span>{feed.comments}</span>
+                  <span>{feed.commentCount || 0}</span>
                 </button>
               </div>
               <div className="flex items-center space-x-2">
@@ -120,7 +128,7 @@ const FeedDetailModal: React.FC<FeedDetailModalProps> = ({
                     disabled={voted}
                   >
                     <i className="fas fa-vote-yea mr-1"></i>
-                    {voted ? '투표완료' : '투표하기'} {feed.votes}
+                    {voted ? '투표완료' : '투표하기'} {feed.participantVoteCount || 0}
                   </button>
                 )}
                 {showEditButton && (

--- a/src/pages/feed/FeedDetailPage.tsx
+++ b/src/pages/feed/FeedDetailPage.tsx
@@ -4,123 +4,6 @@ import { useAuth } from "../../contexts/AuthContext";
 import FeedService from "../../api/feedService";
 import { FeedPost, FeedComment, FeedVoteRequest } from "../../types/feed";
 
-// 더미 데이터 (백엔드 Entity 구조에 맞춘 버전)
-const dummyFeedPosts: FeedPost[] = [
-  {
-    id: 1,
-    title: "데일리 화이트 스니커즈 코디",
-    content: "데일리로 신기 좋은 화이트 스니커즈! 어디에나 잘 어울려요. 편안하고 스타일도 좋아서 매일 신고 다니고 있어요.",
-    instagramId: "daily_lover",
-    feedType: "DAILY",
-    likeCount: 120,
-    commentCount: 8,
-    participantVoteCount: 0,
-    user: {
-      id: 1,
-      nickname: "데일리러버",
-      level: 2,
-      profileImg: "https://readdy.ai/api/search-image?query=asian%20woman%20profile&width=60&height=60&seq=profile1",
-      gender: "여성",
-      height: 162,
-    },
-    orderItem: {
-      id: 1,
-      productName: "화이트 스니커즈",
-      size: 240,
-    },
-    images: [
-      {
-        id: 1,
-        imageUrl: "https://readdy.ai/api/search-image?query=casual%20asian%20woman%20outfit&width=400&height=500&seq=post1",
-        sortOrder: 0,
-      },
-      {
-        id: 2,
-        imageUrl: "https://readdy.ai/api/search-image?query=casual%20asian%20woman%20outfit%20side&width=400&height=500&seq=post1a",
-        sortOrder: 1,
-      },
-    ],
-    hashtags: [
-      { id: 1, tag: "데일리룩" },
-      { id: 2, tag: "스니커즈" },
-    ],
-    createdAt: "2025-06-10",
-    isLiked: false,
-  },
-  {
-    id: 2,
-    title: "여름 이벤트 샌들 착용샷",
-    content: "여름 이벤트에 맞춰 시원하게 신은 샌들! 투표 부탁드려요~",
-    instagramId: "event_guy",
-    feedType: "EVENT",
-    likeCount: 80,
-    commentCount: 3,
-    participantVoteCount: 15,
-    user: {
-      id: 2,
-      nickname: "이벤트참가자",
-      level: 3,
-      profileImg: "https://readdy.ai/api/search-image?query=asian%20man%20profile&width=60&height=60&seq=profile2",
-      gender: "남성",
-      height: 175,
-    },
-    orderItem: {
-      id: 2,
-      productName: "여름 샌들",
-      size: 260,
-    },
-    images: [
-      {
-        id: 3,
-        imageUrl: "https://readdy.ai/api/search-image?query=summer%20event%20outfit&width=400&height=500&seq=event1",
-        sortOrder: 0,
-      },
-    ],
-    hashtags: [
-      { id: 3, tag: "여름이벤트" },
-      { id: 4, tag: "샌들" },
-    ],
-    createdAt: "2025-06-25",
-    isLiked: false,
-  },
-];
-
-const dummyComments: FeedComment[] = [
-  {
-    id: 1,
-    content: "정말 예쁘네요! 저도 이런 스타일 도전해보고 싶어요.",
-    createdAt: "2025-06-14 10:30",
-    user: {
-      id: 3,
-      nickname: "패션리스타",
-      level: 3,
-      profileImg: "https://readdy.ai/api/search-image?query=stylish%20young%20asian%20person%20portrait&width=40&height=40&seq=comment1",
-    },
-  },
-  {
-    id: 2,
-    content: "데님 자켓 핏이 너무 좋아요! 어디 제품인지 궁금합니다.",
-    createdAt: "2025-06-14 11:15",
-    user: {
-      id: 4,
-      nickname: "스타일마스터",
-      level: 4,
-      profileImg: "https://readdy.ai/api/search-image?query=fashionable%20young%20asian%20person%20portrait&width=40&height=40&seq=comment2",
-    },
-  },
-  {
-    id: 3,
-    content: "신발 정보 자세히 알 수 있을까요?",
-    createdAt: "2025-06-14 15:20",
-    user: {
-      id: 5,
-      nickname: "슈즈매니아",
-      level: 2,
-      profileImg: "https://readdy.ai/api/search-image?query=casual%20young%20asian%20person%20portrait&width=40&height=40&seq=comment3",
-    },
-  },
-];
-
 const FeedDetailPage = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -145,33 +28,25 @@ const FeedDetailPage = () => {
       }
 
       try {
-        // 🔧 백엔드 API 연동 버전
+        // 백엔드 API 연동
         const feedData = await FeedService.getFeed(parseInt(id));
         setFeed(feedData);
         
-        // 댓글도 API로 가져오기
-        const commentsData = await FeedService.getComments(parseInt(id));
-        setComments(commentsData.content || []);
+        // 댓글도 API로 가져오기 (추후 구현)
+        // const commentsData = await FeedService.getComments(parseInt(id));
+        // setComments(commentsData.content || []);
         
       } catch (error: any) {
         console.error('피드 조회 실패:', error);
         
         if (error.response?.status === 404) {
-          // 피드를 찾을 수 없는 경우 더미 데이터 fallback
-          const feedId = parseInt(id);
-          const foundFeed = dummyFeedPosts.find(f => f.id === feedId);
-
-          if (foundFeed) {
-            setFeed(foundFeed);
-            setComments(dummyComments);
-          } else {
-            navigate('/feeds');
-            return;
-          }
+          setToastMessage("피드를 찾을 수 없습니다.");
+          setShowToast(true);
+          setTimeout(() => navigate('/feeds'), 2000);
         } else {
-          // 기타 에러의 경우 목록으로 이동
-          navigate('/feeds');
-          return;
+          setToastMessage("피드 조회에 실패했습니다.");
+          setShowToast(true);
+          setTimeout(() => navigate('/feeds'), 2000);
         }
       } finally {
         setLoading(false);
@@ -182,33 +57,21 @@ const FeedDetailPage = () => {
   }, [id, navigate]);
 
   const handleLike = async () => {
-    if (!feed) return;  // liked 조건 제거
+    if (!feed) return;
     
     try {
-      // 🔧 백엔드 API 연동 버전
-      const likeResult = await FeedService.likeFeed(feed.id);
+      // 백엔드 API 연동 (추후 구현)
+      // const likeResult = await FeedService.likeFeed(feed.id);
+      // setLiked(likeResult.liked);
+      // setFeed(prev => prev ? { ...prev, likeCount: likeResult.likeCount } : null);
       
-      setLiked(likeResult.liked);
-      setFeed(prev => prev ? { ...prev, likeCount: likeResult.likeCount } : null);
-      
-      // 백엔드 응답의 메시지 사용 또는 상태에 따른 동적 메시지
-      const message = likeResult.liked ? "좋아요가 추가되었습니다!" : "좋아요가 취소되었습니다!";
-      setToastMessage(message);
+      setToastMessage("좋아요 기능은 추후 구현 예정입니다.");
       setShowToast(true);
       setTimeout(() => setShowToast(false), 2000);
       
     } catch (error: any) {
       console.error('좋아요 실패:', error);
-      
-      if (error.response?.status === 401) {
-        setToastMessage("로그인이 필요합니다.");
-        setTimeout(() => navigate('/login'), 2000);
-      } else if (error.response?.status === 409) {
-        setToastMessage("처리 중 오류가 발생했습니다.");  // 409는 중복이 아닌 다른 오류일 수 있음
-      } else {
-        setToastMessage(error.response?.data?.message || "좋아요 처리에 실패했습니다.");
-      }
-      
+      setToastMessage("좋아요 처리에 실패했습니다.");
       setShowToast(true);
       setTimeout(() => setShowToast(false), 3000);
     }
@@ -218,42 +81,23 @@ const FeedDetailPage = () => {
     if (!feed || voted) return;
     
     try {
-      // 🔧 백엔드 API 연동 버전
-      if (!feed.event) {
-        setToastMessage("투표할 수 있는 이벤트가 없습니다.");
-        setShowToast(true);
-        setTimeout(() => setShowToast(false), 2000);
-        return;
-      }
+      // 백엔드 API 연동 (추후 구현)
+      // const voteRequest: FeedVoteRequest = {
+      //   eventId: feed.event.id
+      // };
+      // const voteResult = await FeedService.voteFeed(feed.id, voteRequest);
+      // setVoted(voteResult.voted);
+      // setFeed(prev => prev ? { ...prev, participantVoteCount: voteResult.voteCount } : null);
       
-      const voteRequest: FeedVoteRequest = {
-        eventId: feed.event.id
-      };
-      
-      const voteResult = await FeedService.voteFeed(feed.id, voteRequest);
-      
-      setVoted(voteResult.voted);
-      setFeed(prev => prev ? { ...prev, participantVoteCount: voteResult.voteCount } : null);
       setShowVoteModal(false);
-      setToastMessage("투표가 완료되었습니다!");
+      setToastMessage("투표 기능은 추후 구현 예정입니다.");
       setShowToast(true);
       setTimeout(() => setShowToast(false), 2000);
       
     } catch (error: any) {
       console.error('투표 실패:', error);
       setShowVoteModal(false);
-      
-      if (error.response?.status === 401) {
-        setToastMessage("로그인이 필요합니다.");
-        setTimeout(() => navigate('/login'), 2000);
-      } else if (error.response?.status === 409) {
-        setToastMessage("이미 투표하셨습니다.");
-      } else if (error.response?.status === 403) {
-        setToastMessage("투표 권한이 없습니다.");
-      } else {
-        setToastMessage(error.response?.data?.message || "투표 처리에 실패했습니다.");
-      }
-      
+      setToastMessage("투표 처리에 실패했습니다.");
       setShowToast(true);
       setTimeout(() => setShowToast(false), 3000);
     }
@@ -264,31 +108,21 @@ const FeedDetailPage = () => {
     if (!newComment.trim() || !feed) return;
 
     try {
-      // 🔧 백엔드 API 연동 버전
-      const newCommentObj = await FeedService.createComment(feed.id, {
-        content: newComment
-      });
-
-      setComments([...comments, newCommentObj]);
+      // 백엔드 API 연동 (추후 구현)
+      // const newCommentObj = await FeedService.createComment(feed.id, {
+      //   content: newComment
+      // });
+      // setComments([...comments, newCommentObj]);
+      // setFeed(prev => prev ? { ...prev, commentCount: prev.commentCount + 1 } : null);
+      
       setNewComment("");
-      
-      // 댓글 수 증가
-      setFeed(prev => prev ? { ...prev, commentCount: prev.commentCount + 1 } : null);
-      
-      setToastMessage("댓글이 등록되었습니다!");
+      setToastMessage("댓글 기능은 추후 구현 예정입니다.");
       setShowToast(true);
       setTimeout(() => setShowToast(false), 2000);
       
     } catch (error: any) {
       console.error('댓글 등록 실패:', error);
-      
-      if (error.response?.status === 401) {
-        setToastMessage("로그인이 필요합니다.");
-        setTimeout(() => navigate('/login'), 2000);
-      } else {
-        setToastMessage(error.response?.data?.message || "댓글 등록에 실패했습니다.");
-      }
-      
+      setToastMessage("댓글 등록에 실패했습니다.");
       setShowToast(true);
       setTimeout(() => setShowToast(false), 3000);
     }
@@ -302,32 +136,15 @@ const FeedDetailPage = () => {
     if (!feed || !window.confirm("정말로 이 피드를 삭제하시겠습니까?")) return;
     
     try {
-      // 🔧 백엔드 API 연동 버전
-      await FeedService.deleteFeed(feed.id);
+      // 백엔드 API 연동 (추후 구현)
+      // await FeedService.deleteFeed(feed.id);
       
-      setToastMessage("피드가 삭제되었습니다!");
+      setToastMessage("삭제 기능은 추후 구현 예정입니다.");
       setShowToast(true);
-      
-      // 1초 후 피드 목록으로 이동
-      setTimeout(() => {
-        navigate('/feeds');
-      }, 1000);
       
     } catch (error: any) {
       console.error('피드 삭제 실패:', error);
-      
-      // 에러 타입별 처리
-      if (error.response?.status === 401) {
-        setToastMessage("로그인이 필요합니다.");
-        setTimeout(() => navigate('/login'), 2000);
-      } else if (error.response?.status === 403) {
-        setToastMessage("삭제 권한이 없습니다.");
-      } else if (error.response?.status === 404) {
-        setToastMessage("피드를 찾을 수 없습니다.");
-      } else {
-        setToastMessage(error.response?.data?.message || "피드 삭제에 실패했습니다. 다시 시도해 주세요.");
-      }
-      
+      setToastMessage("피드 삭제에 실패했습니다.");
       setShowToast(true);
       setTimeout(() => setShowToast(false), 3000);
     }
@@ -377,41 +194,49 @@ const FeedDetailPage = () => {
           {/* 이미지 섹션 */}
           <div className="lg:w-1/2">
             <div className="relative">
-              <img
-                src={feed.images[currentImageIndex]?.imageUrl}
-                alt={feed.title}
-                className="w-full h-96 lg:h-[600px] object-cover"
-              />
-              
-              {/* 이미지 네비게이션 */}
-              {feed.images.length > 1 && (
+              {feed.images && feed.images.length > 0 ? (
                 <>
-                  <button
-                    onClick={() => setCurrentImageIndex(prev => prev === 0 ? feed.images.length - 1 : prev - 1)}
-                    className="absolute left-4 top-1/2 transform -translate-y-1/2 bg-black bg-opacity-50 text-white p-2 rounded-full hover:bg-opacity-70"
-                  >
-                    <i className="fas fa-chevron-left"></i>
-                  </button>
-                  <button
-                    onClick={() => setCurrentImageIndex(prev => prev === feed.images.length - 1 ? 0 : prev + 1)}
-                    className="absolute right-4 top-1/2 transform -translate-y-1/2 bg-black bg-opacity-50 text-white p-2 rounded-full hover:bg-opacity-70"
-                  >
-                    <i className="fas fa-chevron-right"></i>
-                  </button>
+                  <img
+                    src={feed.images[currentImageIndex]?.imageUrl}
+                    alt={feed.title}
+                    className="w-full h-96 lg:h-[600px] object-cover"
+                  />
                   
-                  {/* 이미지 인디케이터 */}
-                  <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 flex space-x-2">
-                    {feed.images.map((_, index) => (
+                  {/* 이미지 네비게이션 */}
+                  {feed.images.length > 1 && (
+                    <>
                       <button
-                        key={index}
-                        onClick={() => setCurrentImageIndex(index)}
-                        className={`w-2 h-2 rounded-full ${
-                          index === currentImageIndex ? 'bg-white' : 'bg-white bg-opacity-50'
-                        }`}
-                      />
-                    ))}
-                  </div>
+                        onClick={() => setCurrentImageIndex(prev => prev === 0 ? feed.images.length - 1 : prev - 1)}
+                        className="absolute left-4 top-1/2 transform -translate-y-1/2 bg-black bg-opacity-50 text-white p-2 rounded-full hover:bg-opacity-70"
+                      >
+                        <i className="fas fa-chevron-left"></i>
+                      </button>
+                      <button
+                        onClick={() => setCurrentImageIndex(prev => prev === feed.images.length - 1 ? 0 : prev + 1)}
+                        className="absolute right-4 top-1/2 transform -translate-y-1/2 bg-black bg-opacity-50 text-white p-2 rounded-full hover:bg-opacity-70"
+                      >
+                        <i className="fas fa-chevron-right"></i>
+                      </button>
+                      
+                      {/* 이미지 인디케이터 */}
+                      <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 flex space-x-2">
+                        {feed.images.map((_, index) => (
+                          <button
+                            key={index}
+                            onClick={() => setCurrentImageIndex(index)}
+                            className={`w-2 h-2 rounded-full ${
+                              index === currentImageIndex ? 'bg-white' : 'bg-white bg-opacity-50'
+                            }`}
+                          />
+                        ))}
+                      </div>
+                    </>
+                  )}
                 </>
+              ) : (
+                <div className="w-full h-96 lg:h-[600px] bg-gray-200 flex items-center justify-center">
+                  <span className="text-gray-500">이미지가 없습니다</span>
+                </div>
               )}
             </div>
           </div>
@@ -422,20 +247,24 @@ const FeedDetailPage = () => {
             <div className="flex items-center justify-between mb-6">
               <div className="flex items-center">
                 <img
-                  src={feed.user.profileImg || "https://readdy.ai/api/search-image?query=default%20profile&width=60&height=60"}
-                  alt={feed.user.nickname}
+                  src={feed.user?.profileImg || "https://readdy.ai/api/search-image?query=default%20profile&width=60&height=60"}
+                  alt={feed.user?.nickname || "사용자"}
                   className="w-12 h-12 rounded-full object-cover mr-3"
                 />
                 <div>
                   <div className="flex items-center">
-                    <h3 className="font-medium text-lg">{feed.user.nickname}</h3>
-                    <div className="ml-2 bg-[#87CEEB] text-white text-xs px-2 py-0.5 rounded-full flex items-center">
-                      <i className="fas fa-crown text-yellow-300 mr-1 text-xs"></i>
-                      <span>Lv.{feed.user.level || 1}</span>
-                    </div>
+                    <h3 className="font-medium text-lg">{feed.user?.nickname || "사용자"}</h3>
+                    {feed.user?.level && (
+                      <div className="ml-2 bg-[#87CEEB] text-white text-xs px-2 py-0.5 rounded-full flex items-center">
+                        <i className="fas fa-crown text-yellow-300 mr-1 text-xs"></i>
+                        <span>Lv.{feed.user.level}</span>
+                      </div>
+                    )}
                   </div>
                   <div className="flex items-center text-sm text-gray-500 mt-1">
-                    <span>{feed.user.gender} · {feed.user.height}cm</span>
+                    {feed.user?.gender && feed.user?.height && (
+                      <span>{feed.user.gender} · {feed.user.height}cm</span>
+                    )}
                     {feed.instagramId && (
                       <a
                         href={`https://instagram.com/${feed.instagramId}`}
@@ -472,13 +301,17 @@ const FeedDetailPage = () => {
             {/* 상품 정보 */}
             <div className="mb-6">
               <h2 className="text-xl font-bold mb-2">{feed.title}</h2>
-              <p className="text-gray-600">상품명: {feed.orderItem.productName}</p>
-              {feed.orderItem.size && <p className="text-gray-600">신발 사이즈: {feed.orderItem.size}mm</p>}
+              {feed.orderItem && (
+                <>
+                  <p className="text-gray-600">상품명: {feed.orderItem.productName}</p>
+                  {feed.orderItem.size && <p className="text-gray-600">신발 사이즈: {feed.orderItem.size}mm</p>}
+                </>
+              )}
               <p className="text-gray-500 text-sm">작성일: {feed.createdAt}</p>
             </div>
 
             {/* 해시태그 */}
-            {feed.hashtags.length > 0 && (
+            {feed.hashtags && feed.hashtags.length > 0 && (
               <div className="mb-4">
                 <div className="flex flex-wrap gap-2">
                   {feed.hashtags.map((hashtag) => (
@@ -509,12 +342,12 @@ const FeedDetailPage = () => {
                   }`}
                 >
                   <i className={`fas fa-heart mr-2 ${liked ? 'text-red-500' : ''}`}></i>
-                  <span>{feed.likeCount}</span>
+                  <span>{feed.likeCount || 0}</span>
                 </button>
                 
                 <div className="flex items-center text-gray-500">
                   <i className="fas fa-comment mr-2"></i>
-                  <span>{feed.commentCount}</span>
+                  <span>{feed.commentCount || 0}</span>
                 </div>
               </div>
 
@@ -529,7 +362,7 @@ const FeedDetailPage = () => {
                   disabled={voted}
                 >
                   <i className="fas fa-vote-yea mr-1"></i>
-                  {voted ? '투표완료' : '투표하기'} {feed.participantVoteCount}
+                  {voted ? '투표완료' : '투표하기'} {feed.participantVoteCount || 0}
                 </button>
               )}
             </div>
@@ -543,16 +376,18 @@ const FeedDetailPage = () => {
                 {comments.map((comment) => (
                   <div key={comment.id} className="flex space-x-3">
                     <img
-                      src={comment.user.profileImg || "https://readdy.ai/api/search-image?query=default%20profile&width=40&height=40"}
-                      alt={comment.user.nickname}
+                      src={comment.user?.profileImg || "https://readdy.ai/api/search-image?query=default%20profile&width=40&height=40"}
+                      alt={comment.user?.nickname || "사용자"}
                       className="w-8 h-8 rounded-full object-cover"
                     />
                     <div className="flex-1">
                       <div className="flex items-center mb-1">
-                        <span className="font-medium text-sm">{comment.user.nickname}</span>
-                        <div className="ml-2 bg-[#87CEEB] bg-opacity-10 text-[#87CEEB] text-xs px-2 py-0.5 rounded-full">
-                          Lv.{comment.user.level || 1}
-                        </div>
+                        <span className="font-medium text-sm">{comment.user?.nickname || "사용자"}</span>
+                        {comment.user?.level && (
+                          <div className="ml-2 bg-[#87CEEB] bg-opacity-10 text-[#87CEEB] text-xs px-2 py-0.5 rounded-full">
+                            Lv.{comment.user.level}
+                          </div>
+                        )}
                         <span className="ml-2 text-xs text-gray-500">{comment.createdAt}</span>
                       </div>
                       <p className="text-sm text-gray-700">{comment.content}</p>
@@ -612,7 +447,7 @@ const FeedDetailPage = () => {
       {showToast && (
         <div className="fixed bottom-4 right-4 bg-[#87CEEB] text-white px-6 py-3 rounded-lg shadow-lg z-50 animate-fade-in-up">
           <div className="flex items-center">
-            <i className="fas fa-check-circle mr-2"></i>
+            <i className="fas fa-check-circle mr-1"></i>
             <span>{toastMessage}</span>
           </div>
         </div>

--- a/src/pages/feed/FeedDetailPage.tsx
+++ b/src/pages/feed/FeedDetailPage.tsx
@@ -23,13 +23,15 @@ const FeedDetailPage = () => {
   useEffect(() => {
     const fetchFeed = async () => {
       if (!id) {
+        console.log('ID가 없어서 피드 목록으로 이동');
         navigate('/feeds');
         return;
       }
 
       try {
         setLoading(true);
-        console.log(`피드 ${id} 조회 시작`);
+        console.log(`피드 ${id} 조회 시작 (타입: ${typeof id})`);
+        console.log(`parseInt(${id}) = ${parseInt(id)}`);
         
         // 백엔드 API 연동
         const feedData = await FeedService.getFeed(parseInt(id));

--- a/src/pages/feed/FeedDetailPage.tsx
+++ b/src/pages/feed/FeedDetailPage.tsx
@@ -28,8 +28,12 @@ const FeedDetailPage = () => {
       }
 
       try {
+        setLoading(true);
+        console.log(`피드 ${id} 조회 시작`);
+        
         // 백엔드 API 연동
         const feedData = await FeedService.getFeed(parseInt(id));
+        console.log('피드 데이터:', feedData);
         setFeed(feedData);
         
         // 댓글도 API로 가져오기 (추후 구현)

--- a/src/pages/feed/FeedListPage.tsx
+++ b/src/pages/feed/FeedListPage.tsx
@@ -176,21 +176,6 @@ const FeedListPage = () => {
       
     } catch (error: any) {
       console.error('피드 목록 조회 실패:', error);
-      
-      // 백엔드 연결 실패시 더미 데이터 사용
-      if (error.code === 'NETWORK_ERROR' || error.response?.status >= 500) {
-        console.warn('백엔드 서버 연결 실패 - 더미 데이터 사용');
-        const dummyFeeds = Array.from({ length: postsPerPage }, (_, i) => 
-          generateDummyFeed((page - 1) * postsPerPage + i + 1)
-        );
-        
-        return {
-          feeds: dummyFeeds,
-          hasMore: page < 3,
-          totalPages: 3
-        };
-      }
-      
       return { feeds: [], hasMore: false, totalPages: 0 };
     }
   };
@@ -234,7 +219,11 @@ const FeedListPage = () => {
 
   // 피드 상세 페이지로 이동
   const handleFeedClick = (feed: FeedPost) => {
-    navigate(`/feed/${feed.id}`);
+    console.log('피드 클릭됨:', feed);
+    console.log('피드 ID:', feed.id, '타입:', typeof feed.id);
+    const url = `/feed/${feed.id}`;
+    console.log('이동할 URL:', url);
+    navigate(url);
   };
 
   // 🔧 백엔드 연동 버전: 좋아요 토글

--- a/src/pages/feed/MyFeedPage.tsx
+++ b/src/pages/feed/MyFeedPage.tsx
@@ -243,9 +243,9 @@ const MyFeedPage = () => {
         return;
       }
       
-             // 임시로 eventId를 1로 설정 (실제로는 피드에서 eventId를 가져와야 함)
-       const voteRequest: FeedVoteRequest = { eventId: 1 };
-       const voteResult = await FeedService.voteFeed(postId, voteRequest);
+      // 임시로 eventId를 1로 설정 (실제로는 피드에서 eventId를 가져와야 함)
+      const voteRequest: FeedVoteRequest = { eventId: 1 };
+      const voteResult = await FeedService.voteFeed(postId, voteRequest);
       
       setVotedPosts([...votedPosts, postId]);
 


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약해주세요 -->
백엔드 응답(`feedId`, `imageUrls`, `user*` 등)을 프론트엔드 `FeedPost`로 매핑하고, 상세 페이지/모달의 데이터 모델을 통합했으며, `develop` 최신을 반영했습니다.  
피드 목록 → 상세 페이지 네비게이션 정비했습니다.

**Type**
- [ ] ✨ Feature
- [X] 🐛 Bug Fix
- [X] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?
<!-- 구현한 기능이나 수정한 내용을 설명해주세요 -->
- 백엔드 응답을 프론트엔드 타입(`FeedPost`)에 맞게 변환
- 목록/상세/마이피드 API 응답의 `feedId` → `id`, `imageUrls` → `images[*].imageUrl`, `user*` 필드 매핑
- 상세 모달과 상세 페이지가 동일한 데이터 모델을 사용하도록 통합
- 피드 목록에서 상세 페이지로 이동 시 데이터 불일치로 인한 "피드를 찾을 수 없습니다" 문제 해결
- 마이피드 페이지의 투표 로직을 `feedType === 'EVENT'` 기준으로 통일, `event?.id`로 안전하게 처리
- 더미 데이터 사용 로직 제거 (실제 SQL 데이터만 사용)
- `develop` 최신 변경사항 병합 및 충돌 해결

### 왜 필요했나요?
<!-- 이 작업이 필요한 이유나 해결하려는 문제를 설명해주세요 -->
- 목록/상세/모달 간 데이터 구조 불일치로 상세 진입 시 404/에러가 발생
- 더미 데이터로 인해 실제 데이터와 다른 동작이 발생
- 마이피드 투표 로직이 타입/필드 불일치로 잘못 동작할 수 있었음
---

## 🔧 How (구현 방법)
### 주요 변경사항
- **`src/api/feedService.ts`**
  - `getFeeds`, `getFeed`, `getMyFeeds` 응답을 `FeedPost`로 변환
  - 백엔드 응답 타입 `BackendFeedPost` 추가
  - 이벤트 필드 매핑 시 필수 필드 존재 여부 가드
  - 더미 데이터 제거, 로깅 추가

- **`src/components/feed/FeedDetailModal.tsx`**
  - 모달의 데이터 필드를 `FeedPost` 기반으로 전면 수정  
    (이미지/작성자/내용/카운트/투표 수 등)

- **`src/components/feed/FeedCard.tsx`**
  - 카드가 `FeedPost` 구조를 사용하도록 정비  
    (대표 이미지, 작성자, 생성일, 좋아요 수 등)

- **`src/pages/feed/FeedListPage.tsx`**
  - 더미 데이터 제거
  - 클릭 시 `/feed/:id` 네비게이션 및 로깅

- **`src/pages/feed/MyFeedPage.tsx`**
  - `develop` 병합 충돌 해결


### 기술적 접근
- 백엔드 응답 → 프론트 타입 변환 계층을 `feedService` 내부로 모아 도메인 일관성 확보
- 모달/페이지가 동일한 `FeedPost`를 사용하게 하여 화면 간 동작 차이 제거
- 예외 상황(이벤트 필드 누락)을 안전 가드로 처리하여 런타임 에러 방지
- 인증은 `axios` 인터셉터로 처리 (`Authorization` 헤더 자동 부착)

---

## 🧪 Testing
### 테스트 방법
<!-- 어떻게 테스트했는지 설명해주세요 -->
1. 목록(`/feeds`)에서 카드 클릭 → 상세 페이지 정상 진입 확인
2. 마이피드(`/my-feed`)에서 카드 클릭 → 모달 내용이 상세 페이지와 동일하게 표시되는지 확인
3. 비로그인 상태에서 `/api/feeds/my` 호출 시 400 반환됨  
   (→ 백엔드는 401로 내려주면 더 바람직)

### 확인 사항
- [X] 기능 정상 동작 확인
- [X] 기존 기능 영향 없음
- [X] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 관련 이슈:
- 지라 백로그: MYCE-93
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->
- 백엔드가 인증 실패를 400이 아닌 401/403으로 내려주면 프론트의 인증 흐름(리다이렉트)이 더 자연스럽습니다.
- 댓글/좋아요/투표 API는 후속 단계에서 처리 예정입니다.
---

## ✅ Checklist
- [X] 코드 리뷰 준비 완료
- [X] 테스트 완료
- [X] 불필요한 로그 제거
