### PR TITLE
MYCE-96: refactor/feed - FeedDetailPage.tsx, FeedDetailCard.tsx 피드 삭제 API 적용

### DIFF
--- a/src/components/feed/FeedDetailModal.tsx
+++ b/src/components/feed/FeedDetailModal.tsx
@@ -13,8 +13,10 @@ interface FeedDetailModalProps {
   onVote?: () => void;
   voted?: boolean;
   onEdit?: () => void;
+  onDelete?: () => void;
   showVoteButton?: boolean;
   showEditButton?: boolean;
+  showDeleteButton?: boolean; // optional; defaults to showEditButton when undefined
   showVoteModal?: boolean;
   onVoteModalClose?: () => void;
   onVoteConfirm?: () => void;
@@ -37,8 +39,10 @@ const FeedDetailModal: React.FC<FeedDetailModalProps> = ({
   onVote,
   voted,
   onEdit,
+  onDelete,
   showVoteButton,
   showEditButton,
+  showDeleteButton,
   showVoteModal,
   onVoteModalClose,
   onVoteConfirm,
@@ -50,6 +54,7 @@ const FeedDetailModal: React.FC<FeedDetailModalProps> = ({
 }) => {
   if (!open || !feed) return null;
   const heroImage = feed.images && feed.images.length > 0 ? feed.images[0].imageUrl : 'https://via.placeholder.com/600x800?text=No+Image';
+  const canShowDelete = (showDeleteButton ?? showEditButton) && !!onDelete;
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4">
       <div className="bg-white rounded-lg max-w-2xl w-full max-h-[90vh] overflow-y-auto relative">
@@ -139,6 +144,14 @@ const FeedDetailModal: React.FC<FeedDetailModalProps> = ({
                     수정
                   </button>
                 )}
+                {canShowDelete && (
+                  <button
+                    className="px-3 py-2 rounded-lg bg-red-100 text-red-700 hover:bg-red-200 transition text-sm font-medium"
+                    onClick={onDelete}
+                  >
+                    삭제
+                  </button>
+                )}
               </div>
             </div>
             {/* 투표 확인 모달 */}
@@ -169,7 +182,7 @@ const FeedDetailModal: React.FC<FeedDetailModalProps> = ({
               <div className="fixed bottom-4 right-4 bg-[#87CEEB] text-white px-6 py-3 rounded-lg shadow-lg z-[70] animate-fade-in-up">
                 <div className="flex items-center">
                   <i className="fas fa-check-circle mr-2"></i>
-                  <span>{toastMessage || '투표가 완료되었습니다!'}</span>
+                  <span>{toastMessage || '처리가 완료되었습니다.'}</span>
                 </div>
               </div>
             )}

--- a/src/pages/feed/FeedDetailPage.tsx
+++ b/src/pages/feed/FeedDetailPage.tsx
@@ -23,19 +23,13 @@ const FeedDetailPage = () => {
   useEffect(() => {
     const fetchFeed = async () => {
       if (!id) {
-        console.log('ID가 없어서 피드 목록으로 이동');
         navigate('/feeds');
         return;
       }
 
       try {
-        setLoading(true);
-        console.log(`피드 ${id} 조회 시작 (타입: ${typeof id})`);
-        console.log(`parseInt(${id}) = ${parseInt(id)}`);
-        
         // 백엔드 API 연동
         const feedData = await FeedService.getFeed(parseInt(id));
-        console.log('피드 데이터:', feedData);
         setFeed(feedData);
         
         // 댓글도 API로 가져오기 (추후 구현)
@@ -140,19 +134,25 @@ const FeedDetailPage = () => {
 
   const handleDelete = async () => {
     if (!feed || !window.confirm("정말로 이 피드를 삭제하시겠습니까?")) return;
-    
     try {
-      // 백엔드 API 연동 (추후 구현)
-      // await FeedService.deleteFeed(feed.id);
-      
-      setToastMessage("삭제 기능은 추후 구현 예정입니다.");
+      await FeedService.deleteFeed(feed.id);
+      setToastMessage("피드가 삭제되었습니다.");
       setShowToast(true);
-      
+      setTimeout(() => navigate('/feeds'), 1200);
     } catch (error: any) {
       console.error('피드 삭제 실패:', error);
-      setToastMessage("피드 삭제에 실패했습니다.");
+      const status = error?.response?.status;
+      if (status === 401) {
+        setToastMessage("로그인이 필요합니다.");
+      } else if (status === 403) {
+        setToastMessage("본인 피드만 삭제할 수 있습니다.");
+      } else if (status === 404) {
+        setToastMessage("피드를 찾을 수 없거나 이미 삭제되었습니다.");
+      } else {
+        setToastMessage("피드 삭제에 실패했습니다.");
+      }
       setShowToast(true);
-      setTimeout(() => setShowToast(false), 3000);
+      setTimeout(() => setShowToast(false), 2000);
     }
   };
 

--- a/src/pages/feed/MyFeedPage.tsx
+++ b/src/pages/feed/MyFeedPage.tsx
@@ -423,24 +423,21 @@ const MyFeedPage = () => {
         liked={selectedPost ? likedPosts.includes(selectedPost.id) : false}
         onVote={() => setShowVoteModal(true)}
         voted={selectedPost ? votedPosts.includes(selectedPost.id) : false}
-        onEdit={
-          user?.nickname &&
-          selectedPost &&
-          selectedPost.user.nickname === user.nickname
-            ? () => {
-                handleCloseModal();
-                navigate(`/feed-edit?id=${selectedPost.id}`);
-              }
-            : undefined
-        }
+        onEdit={(() => {
+          const isOwner = !!(user?.nickname && selectedPost && selectedPost.user.nickname === user.nickname);
+          if (!isOwner) return undefined;
+          return () => {
+            handleCloseModal();
+            navigate(`/feed-edit?id=${selectedPost?.id}`);
+          };
+        })()}
+        onDelete={(() => {
+          const isOwner = !!(user?.nickname && selectedPost && selectedPost.user.nickname === user.nickname);
+          if (!isOwner || !selectedPost) return undefined;
+          return () => handleDelete(selectedPost.id);
+        })()}
         showVoteButton={selectedPost?.feedType === "EVENT"}
-        showEditButton={
-          !!(
-            user?.nickname &&
-            selectedPost &&
-            selectedPost.user.nickname === user.nickname
-          )
-        }
+        showEditButton={!!(user?.nickname && selectedPost && selectedPost.user.nickname === user.nickname)}
         showVoteModal={showVoteModal}
         onVoteModalClose={() => setShowVoteModal(false)}
         onVoteConfirm={() => selectedPost && handleVote(selectedPost.id)}


### PR DESCRIPTION
…l fields with FeedPost

# 🛍️ Pull Request

## 📋 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약해주세요 -->
마이피드 상세 모달에서 로그인한 본인에게만 수정/삭제 버튼을 노출하고, 모달 데이터 모델을 FeedPost와 일치하도록 리팩터링했습니다.

**Type**
- [X] ✨ Feature
- [ ] 🐛 Bug Fix
- [X] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?
<!-- 구현한 기능이나 수정한 내용을 설명해주세요 -->
- 마이피드 상세 모달에서 작성자 본인만 수정/삭제 버튼을 볼 수 있도록 조건 처리
- `FeedDetailModal`의 데이터 모델을 `FeedPost` 구조(`title`, `content`, `user`, `orderItem`, `images`, `likeCount`, `commentCount`, `participantVoteCount`)로 통일
- 모달에 삭제 핸들러(`onDelete`)와 표시 제어(`showDeleteButton`) 추가, 안전한 표시 조건(`canShowDelete`) 적용
- `MyFeedPage`에서 모달로 `onEdit`/`onDelete`를 소유자에게만 주입하도록 로직 개선

### 왜 필요했나요?
<!-- 이 작업이 필요한 이유나 해결하려는 문제를 설명해주세요 -->
- 로그인한 사용자 본인의 피드임에도 삭제 버튼이 노출되지 않는 문제 해결
- 상세 페이지와 모달 간 데이터 불일치로 인한 표시 오류 방지
- 소유자만 수정/삭제 가능하도록 보안/권한 측면에서 명확한 UI 제공
---

## 🔧 How (구현 방법)
### 주요 변경사항
- **`src/components/feed/FeedDetailModal.tsx`**
  - `FeedPost` 타입 기반으로 필드 매핑 수정
  - 삭제 버튼/핸들러(`onDelete`, `showDeleteButton`) 추가
  - 안전한 표시 조건:
    ```ts
    const canShowDelete = (showDeleteButton ?? showEditButton) && !!onDelete;
    ```
- **`src/pages/feed/MyFeedPage.tsx`**
  - 소유자 판단 후에만 `onEdit`/`onDelete` 주입
  - `showEditButton`을 소유자 기준으로 설정
  - 삭제 시 기존 `handleDelete` 호출되도록 연결

### 기술적 접근
- 프론트 도메인 모델(`FeedPost`)로 UI 계층을 일치시켜 화면 간 일관성 확보
- 소유자 판단:  
  ```ts
  selectedPost.user.nickname === user.nickname```
- 버튼 노출은 프롭 주입 기반으로 결정되며, 핸들러 유무까지 확인해 안전성 강화


---

## 🧪 Testing
### 테스트 방법
<!-- 어떻게 테스트했는지 설명해주세요 -->
1. 로그인 후 **마이피드**(`/my-feed`) 진입
2. 본인 피드 카드 클릭 → 상세 모달 열림
3. 수정/삭제 버튼 표시 여부 확인
4. 삭제 클릭 시 확인창 후 삭제되고 리스트에서 제거되는지 확인
5. 본인이 아닌 피드 테스트 (다른 계정/데이터) → 수정/삭제 버튼이 보이지 않아야 함
6. 리스트/상세 모달의 제목, 내용, 이미지, 좋아요/댓글/투표 수 등이 상세 페이지와 동일하게 표시되는지 확인

### 확인 사항
- [X] 기능 정상 동작 확인
- [X] 기존 기능 영향 없음
- [X] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 관련 이슈:
- 지라 백로그: MYCE-96
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->
- 백엔드 삭제 권한 검증 실패 시(`401`/`403`/`404` 등) 기존 에러 처리 플로우에 따라 사용자에게 안내됩니다.
- 모달 삭제 버튼은 `onDelete` 핸들러가 실제로 주입된 경우에만 노출됩니다.

---

## ✅ Checklist
- [X] 코드 리뷰 준비 완료
- [X] 테스트 완료
- [X] 불필요한 로그 제거
