### PR TITLE
MYCE-227 feat: 찜한 상품(추가, 조회, 삭제) UI 및 API 연동

### DIFF
--- a/src/api/wishlistService.ts
+++ b/src/api/wishlistService.ts
@@ -1,0 +1,78 @@
+import { ApiResponse } from "types/feed";
+import axiosInstance from "./axios";
+
+// 찜 목록 응답 타입 정의
+export interface WishlistItem {
+  wishlistId: number;
+  productId: number;
+  productName: string;
+  productImageUrl: string;
+  productPrice: number;
+  discountType: string;
+  discountValue: number;
+  createdAt: string;
+}
+
+export interface WishlistResponse {
+  wishlists: WishlistItem[];
+  totalPages: number;
+  totalElements: number;
+  hasNext: boolean;
+}
+
+export interface AddWishlistRequest {
+  productId: number;
+}
+
+export interface AddWishlistResponse {
+  wishlistId: number;
+  productId: number;
+  createdAt: string;
+}
+
+export class WishlistService {
+  // 찜 목록 추가
+  static async addToWishlist(productId: number): Promise<AddWishlistResponse> {
+    try {
+      const response = await axiosInstance.post<ApiResponse<AddWishlistResponse>>(
+        "/api/users/wishlist",
+        { productId }
+      );
+      return response.data.data;
+    } catch (error: any) {
+      console.error("찜 목록 추가 실패:", error);
+      throw error;
+    }
+  }
+
+  // 찜 목록 조회
+  static async getWishlist(
+    page: number = 0,
+    size: number = 9
+  ): Promise<WishlistResponse> {
+    try {
+      const response = await axiosInstance.get<ApiResponse<WishlistResponse>>(
+        "/api/users/wishlist",
+        { params: { page, size } }
+      );
+      return response.data.data;
+    } catch (error: any) {
+      console.error("찜 목록 조회 실패:", error);
+      throw error;
+    }
+  }
+
+  // 찜 목록에서 제거
+  static async removeFromWishlist(productId: number): Promise<void> {
+    try {
+      await axiosInstance.delete<ApiResponse<null>>(
+        `/api/users/wishlist/${productId}`
+      );
+    } catch (error: any) {
+      console.error("찜 목록 제거 실패:", error);
+      throw error;
+    }
+  }
+}
+
+export default WishlistService;

--- a/src/components/products/ProductCard.tsx
+++ b/src/components/products/ProductCard.tsx
@@ -30,6 +30,7 @@
 import React from "react"; // 컴포넌트 생성을 위한 핵심 React 라이브러리
 import { ProductListItem } from "types/products"; // 상품 목록 항목 데이터 구조를 위한 TypeScript 인터페이스
 import { toUrl } from "../../utils/common/images"; // 이미지 경로를 전체 URL로 변환하는 유틸리티 함수
+import { WishlistButton } from "./WishlistButton"; // 인터랙티브한 찜하기 버튼 컴포넌트
 import {
   ProductCard as StyledProductCard,
   ProductImage,
@@ -39,7 +40,6 @@ import {
   PriceSection,
   DiscountPrice,
   OriginalPrice,
-  WishCount,
 } from "../../pages/products/Lists.styles"; // 상품 카드 UI 요소를 위한 스타일된 컴포넌트
 
 /**
@@ -99,12 +99,13 @@ export const ProductCard: React.FC<ProductCardProps> = ({
           )}
         </PriceSection>
 
-        {/* 위시리스트 수 섹션 - 상품 인기도/소셜 증명 표시 */}
-        <WishCount>
-          <span>❤️</span> {/* 시각적 매력을 위한 하트 이모지 */}
-          <span>{product.wishNumber}</span>{" "}
-          {/* 이 상품을 위시리스트에 추가한 사용자 수 */}
-        </WishCount>
+        {/* 위시리스트 버튼 - 인터랙티브한 찜하기 기능과 소셜 증명 표시 */}
+        <WishlistButton
+          productId={product.productId}
+          wishCount={product.wishNumber}
+          size="small"
+          showCount={true}
+        />
       </ProductInfo>
     </StyledProductCard>
   );

--- a/src/components/products/ProductInfo.tsx
+++ b/src/components/products/ProductInfo.tsx
@@ -30,6 +30,7 @@
 
 import React from "react"; // 컴포넌트 생성을 위한 핵심 React 라이브러리
 import { ProductDetail } from "types/products"; // 상세 상품 데이터 구조를 위한 TypeScript 인터페이스
+import { WishlistButton } from "./WishlistButton"; // 인터랙티브한 찜하기 버튼 컴포넌트
 import {
   InfoSection,
   StoreName,
@@ -97,6 +98,14 @@ export const ProductInfo: React.FC<ProductInfoProps> = ({
         {/* 현재/할인된 가격 - 가장 눈에 띄는 가격 표시 */}
         <CurrentPrice>{formatPrice(product.discountPrice)}원</CurrentPrice>
       </PriceSection>
+
+      {/* 위시리스트 버튼 - 찜하기 기능과 찜한 사람 수 표시 */}
+      <WishlistButton
+        productId={product.productId}
+        wishCount={product.wishNumber}
+        size="medium"
+        showCount={true}
+      />
     </InfoSection>
   );
 };

--- a/src/components/products/WishlistButton.tsx
+++ b/src/components/products/WishlistButton.tsx
@@ -1,0 +1,184 @@
+import React, { useState, useEffect } from "react";
+import styled from "styled-components";
+import { useWishlist } from "hooks/cart/useWishlist";
+import Warning from "components/modal/Warning";
+
+interface WishlistButtonProps {
+  productId: number;
+  wishCount: number;
+  showCount?: boolean;
+  size?: "small" | "medium" | "large";
+  className?: string;
+}
+
+const ButtonContainer = styled.div<{ size: string }>`
+  display: flex;
+  align-items: center;
+  gap: ${({ size }) => (size === "small" ? "4px" : size === "large" ? "8px" : "6px")};
+`;
+
+const HeartButton = styled.button<{ $isWishlisted: boolean; size: string; $isLoading: boolean }>`
+  background: none;
+  border: none;
+  cursor: ${({ $isLoading }) => ($isLoading ? "not-allowed" : "pointer")};
+  padding: ${({ size }) => (size === "small" ? "4px" : size === "large" ? "8px" : "6px")};
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+  font-size: ${({ size }) => (size === "small" ? "1rem" : size === "large" ? "1.5rem" : "1.2rem")};
+  opacity: ${({ $isLoading }) => ($isLoading ? 0.6 : 1)};
+
+  &:hover:not(:disabled) {
+    background: rgba(0, 0, 0, 0.05);
+    transform: scale(1.1);
+  }
+
+  &:active {
+    transform: scale(0.95);
+  }
+
+  .heart-icon {
+    color: ${({ $isWishlisted }) => ($isWishlisted ? "#ef4444" : "#d1d5db")};
+    transition: color 0.2s ease;
+  }
+`;
+
+const WishCount = styled.span<{ size: string }>`
+  font-size: ${({ size }) => (size === "small" ? "0.875rem" : size === "large" ? "1.125rem" : "1rem")};
+  color: #6b7280;
+  font-weight: 500;
+  min-width: ${({ size }) => (size === "small" ? "20px" : "24px")};
+  text-align: left;
+`;
+
+export const WishlistButton: React.FC<WishlistButtonProps> = ({
+  productId,
+  wishCount,
+  showCount = true,
+  size = "medium",
+  className,
+}) => {
+  const { addToWishlist, removeFromWishlist, isWishlisted, loading } = useWishlist();
+  const [isLocalLoading, setIsLocalLoading] = useState(false);
+  const [localWishCount, setLocalWishCount] = useState(wishCount);
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [showRemoveModal, setShowRemoveModal] = useState(false);
+  
+  const isWishlistedItem = isWishlisted(productId);
+  const isCurrentlyLoading = loading || isLocalLoading;
+
+  // wishCount prop이 변경되면 localWishCount 업데이트
+  useEffect(() => {
+    setLocalWishCount(wishCount);
+  }, [wishCount]);
+
+  const handleWishlistToggle = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (isCurrentlyLoading) return;
+
+    if (isWishlistedItem) {
+      setShowRemoveModal(true);
+    } else {
+      setShowAddModal(true);
+    }
+  };
+
+  const handleAddConfirm = async () => {
+    setShowAddModal(false);
+    setIsLocalLoading(true);
+    
+    // 낙관적 업데이트
+    setLocalWishCount(prev => prev + 1);
+    
+    try {
+      const success = await addToWishlist(productId);
+      if (!success) {
+        // 실패 시 롤백
+        setLocalWishCount(prev => prev - 1);
+      }
+    } catch (error) {
+      console.error("찜하기 추가 실패:", error);
+      // 실패 시 롤백
+      setLocalWishCount(prev => prev - 1);
+    } finally {
+      setIsLocalLoading(false);
+    }
+  };
+
+  const handleRemoveConfirm = async () => {
+    setShowRemoveModal(false);
+    setIsLocalLoading(true);
+    
+    // 낙관적 업데이트
+    setLocalWishCount(prev => Math.max(0, prev - 1));
+    
+    try {
+      const success = await removeFromWishlist(productId);
+      if (!success) {
+        // 실패 시 롤백
+        setLocalWishCount(prev => prev + 1);
+      }
+    } catch (error) {
+      console.error("찜하기 제거 실패:", error);
+      // 실패 시 롤백
+      setLocalWishCount(prev => prev + 1);
+    } finally {
+      setIsLocalLoading(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setShowAddModal(false);
+    setShowRemoveModal(false);
+  };
+
+  return (
+    <ButtonContainer size={size} className={className}>
+      <HeartButton
+        onClick={handleWishlistToggle}
+        $isWishlisted={isWishlistedItem}
+        size={size}
+        $isLoading={isCurrentlyLoading}
+        disabled={isCurrentlyLoading}
+        title={isWishlistedItem ? "찜 해제" : "찜하기"}
+        aria-label={isWishlistedItem ? "찜 해제" : "찜하기"}
+      >
+        {isCurrentlyLoading ? (
+          <span className="heart-icon">⏳</span>
+        ) : (
+          <span className="heart-icon">
+            {isWishlistedItem ? "❤️" : "🤍"}
+          </span>
+        )}
+      </HeartButton>
+      
+      {showCount && (
+        <WishCount size={size}>
+          {localWishCount}
+        </WishCount>
+      )}
+
+      {/* 찜하기 확인 모달 */}
+      <Warning
+        open={showAddModal}
+        title="찜하기"
+        message="이 상품을 찜 목록에 추가하시겠습니까?"
+        onConfirm={handleAddConfirm}
+        onCancel={handleCancel}
+      />
+
+      {/* 찜 해제 확인 모달 */}
+      <Warning
+        open={showRemoveModal}
+        title="찜 해제"
+        message="이 상품을 찜 목록에서 제거하시겠습니까?"
+        onConfirm={handleRemoveConfirm}
+        onCancel={handleCancel}
+      />
+    </ButtonContainer>
+  );
+};

--- a/src/hooks/cart/useWishlist.ts
+++ b/src/hooks/cart/useWishlist.ts
@@ -1,0 +1,168 @@
+import { useState, useEffect, useCallback } from "react";
+import { WishlistService, WishlistResponse } from "../../api/wishlistService";
+import { useAuth } from "../../contexts/AuthContext";
+
+interface UseWishlistReturn {
+  // 찜한 상품 목록
+  wishlistItems: WishlistResponse | null;
+  
+  // 찜한 상품 개수
+  wishlistCount: number;
+  
+  // 찜한 상품 목록을 서버에서 다시 가져와서 업데이트하는 함수
+  fetchWishlist: (page?: number, size?: number) => Promise<void>;
+  
+  // 상품을 찜 목록에 추가하는 함수
+  addToWishlist: (productId: number) => Promise<boolean>;
+  
+  // 상품을 찜 목록에서 제거하는 함수
+  removeFromWishlist: (productId: number) => Promise<boolean>;
+  
+  // 특정 상품이 찜되어 있는지 확인하는 함수
+  isWishlisted: (productId: number) => boolean;
+  
+  // 로딩 상태
+  loading: boolean;
+  
+  // 에러 상태
+  error: string | null;
+}
+
+export const useWishlist = (): UseWishlistReturn => {
+  // 상태 관리
+  const [wishlistItems, setWishlistItems] = useState<WishlistResponse | null>(null);
+  const [wishlistCount, setWishlistCount] = useState<number>(0);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  
+  // 인증 상태 가져오기
+  const { user } = useAuth();
+  
+  /**
+   * 서버에서 찜한 상품 목록을 가져와서 업데이트하는 함수
+   */
+  const fetchWishlist = useCallback(async (page: number = 0, size: number = 9): Promise<void> => {
+    // 로그인하지 않은 사용자는 찜 목록을 null로 설정
+    if (!user) {
+      setWishlistItems(null);
+      setWishlistCount(0);
+      setError(null);
+      return;
+    }
+    
+    try {
+      setLoading(true);
+      setError(null);
+      
+      // 서버에서 찜한 상품 목록 가져오기
+      const wishlistData = await WishlistService.getWishlist(page, size);
+      
+      setWishlistItems(wishlistData);
+      setWishlistCount(wishlistData.totalElements);
+    } catch (err: any) {
+      // 에러 발생 시 빈 상태로 설정
+      setWishlistItems(null);
+      setWishlistCount(0);
+      setError(err.message || "찜 목록을 불러오는데 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
+  
+  /**
+   * 상품을 찜 목록에 추가하는 함수
+   */
+  const addToWishlist = useCallback(async (productId: number): Promise<boolean> => {
+    if (!user) {
+      setError("로그인이 필요합니다.");
+      return false;
+    }
+    
+    try {
+      setLoading(true);
+      setError(null);
+      
+      await WishlistService.addToWishlist(productId);
+      
+      // 찜 목록 새로고침
+      await fetchWishlist();
+      
+      return true;
+    } catch (err: any) {
+      const errorMessage = err.response?.data?.message || err.message || "찜 추가에 실패했습니다.";
+      setError(errorMessage);
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  }, [user, fetchWishlist]);
+  
+  /**
+   * 상품을 찜 목록에서 제거하는 함수
+   */
+  const removeFromWishlist = useCallback(async (productId: number): Promise<boolean> => {
+    if (!user) {
+      setError("로그인이 필요합니다.");
+      return false;
+    }
+    
+    try {
+      setLoading(true);
+      setError(null);
+      
+      await WishlistService.removeFromWishlist(productId);
+      
+      // 찜 목록 새로고침
+      await fetchWishlist();
+      
+      return true;
+    } catch (err: any) {
+      const errorMessage = err.response?.data?.message || err.message || "찜 제거에 실패했습니다.";
+      setError(errorMessage);
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  }, [user, fetchWishlist]);
+  
+  /**
+   * 특정 상품이 찜되어 있는지 확인하는 함수
+   */
+  const isWishlisted = useCallback((productId: number): boolean => {
+    if (!wishlistItems) return false;
+    return wishlistItems.wishlists.some(item => item.productId === productId);
+  }, [wishlistItems]);
+  
+  /**
+   * 컴포넌트 마운트 시 찜 목록 초기화
+   */
+  useEffect(() => {
+    fetchWishlist();
+  }, [fetchWishlist]);
+  
+  /**
+   * 로그인 상태 변경 시 찜 목록 재조회
+   */
+  useEffect(() => {
+    if (user) {
+      // 로그인한 경우 찜 목록 조회
+      fetchWishlist();
+    } else {
+      // 로그아웃한 경우 찜 목록 초기화
+      setWishlistItems(null);
+      setWishlistCount(0);
+      setError(null);
+    }
+  }, [user, fetchWishlist]);
+  
+  return {
+    wishlistItems,
+    wishlistCount,
+    fetchWishlist,
+    addToWishlist,
+    removeFromWishlist,
+    isWishlisted,
+    loading,
+    error,
+  };
+};


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
찜하기 기능의 프론트엔드 UI 및 API 연결 구현

**Type**
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore

---

## 🎯 What & Why

### 무엇을 했나요?
- 찜하기 버튼 컴포넌트 구현 (WishlistButton.tsx)
- 찜하기 API 서비스 로직 구현 (wishlistService.ts)
- 찜하기 기능 커스텀 훅 구현 (useWishlist.ts)
- 찜하기 목록 페이지 구현 (WishListPage.tsx)
- 상품 카드 및 상세 페이지에 찜하기 버튼 연동

### 왜 필요했나요?
- 사용자가 관심 상품을 저장하고 관리할 수 있는 기능 필요
- 상품 발견과 구매 결정을 위한 UX 개선
- 사용자 재방문율 증대 및 구매 전환율 향상

---

## 🔧 How (구현 방법)

### 주요 변경사항
- `WishlistButton` 컴포넌트: 하트 아이콘 기반 찜하기/찜해제 버튼
- `WishlistService` API 클래스: 찜하기 추가/조회/제거 API 호출
- `useWishlist` 훅: 찜하기 상태 관리 및 낙관적 업데이트
- `WishListPage` 페이지: 찜한 상품 목록 조회 및 관리

### 기술적 접근
- 낙관적 업데이트로 사용자 경험 향상
- 확인 모달을 통한 의도치 않은 동작 방지
- 로그인 상태에 따른 조건부 렌더링
- 에러 처리 및 로딩 상태 관리

---

## 🧪 Testing

### 테스트 방법
- 로그인/비로그인 상태에서 찜하기 버튼 동작 확인
- 상품 카드 및 상세 페이지에서 찜하기 기능 테스트
- 찜하기 목록 페이지에서 상품 조회/제거 테스트
- 네트워크 오류 상황에서 에러 처리 확인

### 확인 사항
- [x] 기능 정상 동작 확인
- [x] 기존 기능 영향 없음
- [x] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 관련 이슈: #찜하기-기능-구현
- 지라 백로그: WISH-001

---

## 💬 Additional Notes
- 기존 ProductCard, ProductInfo 컴포넌트에 최소한의 변경으로 WishlistButton 추가
- 단순하고 직관적인 하트 아이콘 UI로 사용성 중심 설계
- 불필요한 애니메이션이나 복잡한 상태 로직 제거하여 성능 최적화

---

## ✅ Checklist
- [x] 코드 리뷰 준비 완료
- [x] 테스트 완료
- [x] 불필요한 로그 제거