### PR TITLE
MYCE-185 feat: 구글 소셜 로그인 기능 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,6 +66,7 @@ const EventEditPage = lazy(() => import("./pages/event/EventEditPage"));
 const EventResultPage = lazy(() => import("./pages/event/EventResultPage"));
 const BecomeSellerPage = lazy(() => import("./pages/seller/BecomeSellerPage"));
 const SellerMyPage = lazy(() => import("./pages/seller/SellerMyPage"));
+const SocialCallbackPage = lazy(() => import("./pages/auth/SocialCallbackPage"));
 
 const RECAPTCHA_SITE_KEY = process.env.REACT_APP_RECAPTCHA_SITE_KEY || "";
 
@@ -311,6 +312,7 @@ const App: FC = () => {
               <Route path="/find-account" element={<FindAccountPage />} />
               <Route path="/find-password" element={<FindPasswordPage />} />
               <Route path="/reset-password" element={<ResetPasswordPage />} />
+              <Route path="/auth/callback" element={<SocialCallbackPage />} />
             </Routes>
           </Suspense>
         </AuthProvider>

--- a/src/api/socialAuthService.ts
+++ b/src/api/socialAuthService.ts
@@ -1,0 +1,107 @@
+import axiosInstance from "./axios";
+
+// 소셜 로그인 관련 API 서비스
+
+export interface SocialProvider {
+  provider: string;
+  connected: boolean;
+  email?: string;
+  connectedAt?: string;
+}
+
+export interface SocialLoginResponse {
+  providers: SocialProvider[];
+  totalConnected: number;
+}
+
+export class SocialAuthService {
+  /**
+   * 현재 사용자의 소셜 로그인 연동 정보 조회
+   */
+  static async getUserSocialProviders(): Promise<SocialLoginResponse> {
+    const response = await axiosInstance.get<{
+      success: boolean;
+      data: SocialLoginResponse;
+    }>("/api/social/providers");
+    
+    return response.data.data;
+  }
+
+  /**
+   * 특정 소셜 제공자 연동 해제
+   */
+  static async unlinkProvider(provider: string): Promise<string> {
+    const response = await axiosInstance.delete<{
+      success: boolean;
+      data: string;
+    }>(`/api/social/providers/${provider}`);
+    
+    return response.data.data;
+  }
+
+  /**
+   * 소셜 로그인 지원 제공자 목록 조회
+   */
+  static async getSupportedProviders(): Promise<string[]> {
+    const response = await axiosInstance.get<{
+      success: boolean;
+      data: string[];
+    }>("/api/social/supported-providers");
+    
+    return response.data.data;
+  }
+
+  /**
+   * 소셜 로그인 URL 생성 (개발/테스트용)
+   */
+  static async getSocialLoginUrls(): Promise<{ [key: string]: string }> {
+    const response = await axiosInstance.get<{
+      success: boolean;
+      data: { [key: string]: string };
+    }>("/api/auth/test/social-login-urls");
+    
+    return response.data.data;
+  }
+
+  /**
+   * 현재 인증 상태 확인 (개발/테스트용)
+   */
+  static async getAuthStatus(): Promise<{
+    authenticated: boolean;
+    username?: string;
+    message: string;
+  }> {
+    const response = await axiosInstance.get<{
+      success: boolean;
+      data: {
+        authenticated: boolean;
+        username?: string;
+        message: string;
+      };
+    }>("/api/auth/test/auth-status");
+    
+    return response.data.data;
+  }
+
+  /**
+   * OAuth2 콜백 정보 조회 (개발/테스트용)
+   */
+  static async getCallbackInfo(): Promise<{
+    frontendCallbackUrl: string;
+    description: string;
+    parameters: string;
+  }> {
+    const response = await axiosInstance.get<{
+      success: boolean;
+      data: {
+        frontendCallbackUrl: string;
+        description: string;
+        parameters: string;
+      };
+    }>("/api/auth/test/callback-info");
+    
+    return response.data.data;
+  }
+}
+
+export default SocialAuthService;

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -1,7 +1,7 @@
 import { useAuth } from "../../contexts/AuthContext";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate, useLocation } from "react-router-dom";
 import { validateEmail } from "../../utils/auth/auth";
 import axios from "axios";
 import {
@@ -101,6 +101,7 @@ export default function LoginPage() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
+  const location = useLocation();
   const isEmailValid = validateEmail(email);
   const { login: authLogin } = useAuth();
 
@@ -113,6 +114,14 @@ export default function LoginPage() {
       setIsRecaptchaReady(true);
     }
   }, [executeRecaptcha]);
+
+  // 소셜 로그인 콜백에서 전달된 에러 처리
+  useEffect(() => {
+    const state = location.state as { error?: string } | null;
+    if (state?.error) {
+      setError(state.error);
+    }
+  }, [location.state]);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -156,7 +165,7 @@ export default function LoginPage() {
       const loginData = response.data.data;
       if (loginData && loginData.token) {
         // authLogin 함수를 4개의 인자를 받도록 수정 (name 추가)
-        await authLogin(
+        authLogin(
           loginData.nickname,
           loginData.name || loginData.nickname,
           loginData.role,
@@ -181,6 +190,17 @@ export default function LoginPage() {
     } finally {
       setLoading(false);
     }
+  };
+
+  // 소셜 로그인 핸들러
+  const handleGoogleLogin = () => {
+    const baseURL = process.env.REACT_APP_API_URL || "https://localhost:8443";
+    window.location.href = `${baseURL}/oauth2/authorization/google`;
+  };
+
+  const handleKakaoLogin = () => {
+    const baseURL = process.env.REACT_APP_API_URL || "https://localhost:8443";
+    window.location.href = `${baseURL}/oauth2/authorization/kakao`;
   };
 
   return (
@@ -245,8 +265,8 @@ export default function LoginPage() {
 
         <SocialLoginButton
           type="button"
-          // alert() 대신 console.log로 변경
-          onClick={() => console.log("구글 로그인 연동 필요")}
+          onClick={handleGoogleLogin}
+          disabled={loading}
         >
           <i className="fab fa-google" style={{ color: "#DB4437" }}></i>
           구글로 로그인
@@ -254,8 +274,8 @@ export default function LoginPage() {
 
         <SocialLoginButton
           type="button"
-          // alert() 대신 console.log로 변경
-          onClick={() => console.log("카카오 로그인 연동 필요")}
+          onClick={handleKakaoLogin}
+          disabled={loading}
         >
           <i className="fas fa-comment" style={{ color: "#FEE500" }}></i>
           카카오로 로그인

--- a/src/pages/auth/SocialCallbackPage.tsx
+++ b/src/pages/auth/SocialCallbackPage.tsx
@@ -1,0 +1,130 @@
+import { useEffect } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { useAuth } from "../../contexts/AuthContext";
+import styled from "styled-components";
+
+const CallbackContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+`;
+
+const LoadingSpinner = styled.div`
+  width: 50px;
+  height: 50px;
+  border: 5px solid rgba(255, 255, 255, 0.3);
+  border-top: 5px solid white;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-bottom: 20px;
+
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+`;
+
+const Message = styled.h2`
+  text-align: center;
+  margin-bottom: 10px;
+`;
+
+const SubMessage = styled.p`
+  text-align: center;
+  opacity: 0.8;
+`;
+
+export default function SocialCallbackPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const { login: authLogin } = useAuth();
+
+  useEffect(() => {
+    const handleSocialLoginCallback = async () => {
+      try {
+        // React Router의 useSearchParams 사용
+        // 일반적인 OAuth2 콜백 파라미터들
+        let token =
+          searchParams.get("token") ||
+          searchParams.get("access_token") ||
+          searchParams.get("jwt");
+        let email = searchParams.get("email") || searchParams.get("username");
+        let name = searchParams.get("name") || searchParams.get("displayName");
+        let nickname =
+          searchParams.get("nickname") ||
+          searchParams.get("name") ||
+          searchParams.get("given_name");
+        let provider =
+          searchParams.get("provider") || searchParams.get("social_provider");
+        let role =
+          searchParams.get("role") || searchParams.get("userType") || "user";
+
+        // 에러 처리를 위한 파라미터
+        const error = searchParams.get("error");
+        const errorDescription = searchParams.get("error_description");
+
+        // 에러가 있는 경우 처리
+        if (error) {
+          throw new Error(
+            `소셜 로그인 실패: ${error} ${
+              errorDescription ? `- ${errorDescription}` : ""
+            }`
+          );
+        }
+
+        // Authorization Code가 있는 경우 (OAuth2 표준 플로우)
+        const code = searchParams.get("code");
+        const state = searchParams.get("state");
+
+        if (code && !token) {
+          throw new Error(
+            "Authorization Code 방식은 아직 구현되지 않았습니다. 백엔드에서 직접 JWT 토큰을 전달해주세요."
+          );
+        }
+
+        if (!token || !email) {
+          throw new Error(
+            `필수 로그인 정보가 누락되었습니다. token: ${!!token}, email: ${!!email}`
+          );
+        }
+
+        // AuthContext의 login 함수 호출
+        authLogin(
+          nickname || email, // nickname이 없으면 email 사용
+          name || nickname || email, // name이 없으면 nickname 또는 email 사용
+          role as "user" | "admin" | "seller",
+          token
+        );
+
+        // 홈페이지로 리다이렉트
+        navigate("/", { replace: true });
+      } catch (error: any) {
+        // 에러 발생 시 로그인 페이지로 리다이렉트 (에러 메시지와 함께)
+        navigate("/login", {
+          replace: true,
+          state: {
+            error: error.message || "소셜 로그인 처리 중 오류가 발생했습니다.",
+          },
+        });
+      }
+    };
+
+    handleSocialLoginCallback();
+  }, [navigate, authLogin, searchParams]);
+
+  return (
+    <CallbackContainer>
+      <LoadingSpinner />
+      <Message>소셜 로그인 처리 중...</Message>
+      <SubMessage>잠시만 기다려 주세요.</SubMessage>
+    </CallbackContainer>
+  );
+}


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약해주세요 -->
구글/카카오 소셜 로그인 기능을 백엔드 API와 연동하여 구현

**Type**
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore

---

## 🎯 What & Why
### 무엇을 했나요?
<!-- 구현한 기능이나 수정한 내용을 설명해주세요 -->
- 기존 로그인 페이지의 소셜 로그인 버튼을 백엔드 API와 연동
- 소셜 로그인 성공 후 콜백 처리 페이지 구현
- 소셜 로그인 관련 API 서비스 클래스 추가
- React Router의 useSearchParams를 활용한 URL 파라미터 처리

### 왜 필요했나요?
<!-- 이 작업이 필요한 이유나 해결하려는 문제를 설명해주세요 -->

- 기존 소셜 로그인 버튼이 실제 기능 없이 console.log만 출력하는 상태였음
- 백엔드에서 OAuth2 소셜 로그인 API가 구현되었으나 프론트엔드 연동이 필요했음
- 사용자 편의성을 위해 소셜 계정으로 간편 로그인 기능 제공

---

## 🔧 How (구현 방법)
### 주요 변경사항
- `src/pages/auth/LoginPage.tsx`: 소셜 로그인 핸들러 함수 추가
- `src/pages/auth/SocialCallbackPage.tsx`: 소셜 로그인 콜백 처리 페이지 신규 생성
- `src/App.tsx`: 소셜 콜백 페이지 라우트 추가
- `src/api/socialAuthService.ts`: 소셜 로그인 관련 API 서비스 클래스 신규 생성


### 기술적 접근
- OAuth2 표준 플로우에 따른 리다이렉트 방식 구현
- React Router의 useSearchParams 훅을 활용한 URL 파라미터 안전한 처리
- AuthContext를 통한 통합된 인증 상태 관리
- 에러 처리 및 사용자 피드백 개선

---

## 🧪 Testing
### 테스트 방법
<!-- 어떻게 테스트했는지 설명해주세요 -->
1. 로그인 페이지에서 "구글로 로그인" 버튼 클릭
2. 구글 OAuth2 인증 페이지로 리다이렉트 확인
3. 구글 계정으로 로그인 후 콜백 페이지로 리다이렉트 확인
4. JWT 토큰과 사용자 정보 파싱 및 로그인 처리 확인
5. 홈페이지로 자동 리다이렉트 및 로그인 상태 확인


### 확인 사항
- [x] 기능 정상 동작 확인
- [x] 기존 기능 영향 없음
- [x] 예외 케이스 테스트 완료 (토큰 누락, 에러 파라미터 등)

---

## 📎 관련 이슈 / 문서
- 관련 이슈: 없음
- 지라 백로그: [https://sesac-springboot.atlassian.net/browse/MYCE-185](url)
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->

- 백엔드에서 OAuth2 리다이렉트 URL 설정 필요: `http://localhost:3000/auth/callback`
- 현재 구글, 카카오 소셜 로그인 지원 (네이버는 백엔드에서 지원하지만 UI 미구현)
- Authorization Code 플로우는 백엔드에서 JWT 토큰으로 변환하여 전달하는 방식 사용
- 프로덕션 배포 시 환경변수 `REACT_APP_API_URL` 설정 필요

---

## ✅ Checklist
- [x] 코드 리뷰 준비 완료
- [x] 테스트 완료
- [x] 불필요한 로그 제거
