### PR TITLE
MYCE-296:feat/reviewUserprofile(front) - 리뷰 목록에 사용자 정보 표시 추가 

### DIFF
--- a/src/api/reviewService.ts
+++ b/src/api/reviewService.ts
@@ -13,7 +13,8 @@ import {
     UpdateReviewResponse,
     DeleteReviewResponse,
     ReviewListParams,
-    HelpfulResponse
+    HelpfulResponse,
+    SCORE_TO_ENUM
 } from "../types/review";
 
 // ===== 중복 타입 제거하고 공통 타입 사용 =====
@@ -39,6 +40,21 @@ export class ReviewService {
                 console.log('리뷰 목록 API 호출:', { productId, params });
             }
 
+            // 1-5 점수를 백엔드 enum으로 변환하는 헬퍼 함수
+            const convertScoreToEnum = (type: 'sizeFit' | 'cushion' | 'stability', score: number) => {
+                const enumValue = SCORE_TO_ENUM[type][score as keyof typeof SCORE_TO_ENUM[typeof type]];
+                // 대소문자 문제 방지를 위해 강제로 대문자 변환
+                const finalValue = enumValue?.toUpperCase() || enumValue;
+                if (process.env.NODE_ENV === 'development') {
+                    console.log(`🔄 필터 변환: ${type} ${score} → ${enumValue} → ${finalValue}`);
+                    if (!enumValue) {
+                        console.error(`❌ 변환 실패: ${type}의 ${score} 값에 해당하는 enum을 찾을 수 없습니다.`);
+                        console.log(`🗺️ 사용 가능한 ${type} 매핑:`, SCORE_TO_ENUM[type]);
+                    }
+                }
+                return finalValue;
+            };
+
             const queryParams = {
                 page: params.page || 0,
                 size: params.size || 10,
@@ -47,22 +63,112 @@ export class ReviewService {
                     rating: params.rating,
                     exactRating: params.exactRating || false 
                 }),
-                ...(params.sizeFit && params.sizeFit > 0 && { sizeFit: params.sizeFit }),
-                ...(params.cushion && params.cushion > 0 && { cushion: params.cushion }),
-                ...(params.stability && params.stability > 0 && { stability: params.stability })
+                ...(params.sizeFit && params.sizeFit > 0 && { 
+                    sizeFit: convertScoreToEnum('sizeFit', params.sizeFit)
+                }),
+                ...(params.cushion && params.cushion > 0 && { 
+                    cushion: convertScoreToEnum('cushion', params.cushion)
+                }),
+                ...(params.stability && params.stability > 0 && { 
+                    stability: convertScoreToEnum('stability', params.stability)
+                })
             };
 
             if (process.env.NODE_ENV === 'development') {
                 console.log('🔍 실제 전송될 queryParams:', queryParams);
+                
+                // 3요소 필터 매핑 상세 로그
+                if (params.sizeFit) {
+                    console.log(`📊 sizeFit 필터: ${params.sizeFit} → ${queryParams.sizeFit}`);
+                }
+                if (params.cushion) {
+                    console.log(`📊 cushion 필터: ${params.cushion} → ${queryParams.cushion}`);
+                }
+                if (params.stability) {
+                    console.log(`📊 stability 필터: ${params.stability} → ${queryParams.stability}`);
+                }
+                
+                // URL 파라미터 문자열 확인
+                const urlParams = new URLSearchParams();
+                Object.entries(queryParams).forEach(([key, value]) => {
+                    if (value !== undefined && value !== null) {
+                        urlParams.append(key, String(value));
+                    }
+                });
+                const finalUrl = `/api/reviews/products/${productId}/filter?${urlParams.toString()}`;
+                console.log('🌐 최종 요청 URL:', finalUrl);
+                
+                // SCORE_TO_ENUM 매핑 테이블 확인
+                console.log('🗺️ SCORE_TO_ENUM 매핑 테이블:', SCORE_TO_ENUM);
+            }
+
+            // axios 요청 전에 실제 URL 로깅
+            if (process.env.NODE_ENV === 'development') {
+                // axios interceptor로 실제 요청 URL 캡처
+                const originalRequest = axiosInstance.interceptors.request.use(
+                    (config) => {
+                        console.log('🚀 axios 실제 요청 URL:', config.url);
+                        console.log('🚀 axios 실제 요청 params:', config.params);
+                        axiosInstance.interceptors.request.eject(originalRequest);
+                        return config;
+                    }
+                );
             }
 
             const response = await axiosInstance.get<ApiResponse<ReviewListResponse>>(
-                `/api/reviews/products/${productId}`,
+                `/api/reviews/products/${productId}/filter`,
                 { params: queryParams }
             );
 
             if (process.env.NODE_ENV === 'development') {
-                console.log('리뷰 목록 API 응답:', response.data);
+                console.log('🔍 리뷰 목록 API 응답:', response.data);
+                console.log('🔍 API 응답 데이터 구조 분석:', {
+                    hasData: !!response.data?.data,
+                    dataKeys: response.data?.data ? Object.keys(response.data.data) : null,
+                    dataType: typeof response.data?.data,
+                    fullData: response.data?.data
+                });
+                
+                // 필터링 결과 검증  
+                if (response.data?.data?.reviews && Array.isArray(response.data.data.reviews)) {
+                    const reviews = response.data.data.reviews;
+                    console.log(`📋 응답된 리뷰 ${reviews.length}개:`);
+                    
+                    reviews.forEach((review, idx) => {
+                        console.log(`  리뷰 ${idx + 1} (ID: ${review.reviewId}):`, {
+                            sizeFit: review.sizeFit,
+                            cushion: review.cushion,
+                            stability: review.stability,
+                            userName: review.userName
+                        });
+                    });
+
+                    // 필터 조건 체크
+                    if (queryParams.sizeFit) {
+                        const matchingReviews = reviews.filter(r => r.sizeFit === queryParams.sizeFit);
+                        console.log(`🔍 sizeFit="${queryParams.sizeFit}" 조건에 맞는 리뷰: ${matchingReviews.length}/${reviews.length}개`);
+                        
+                        if (matchingReviews.length !== reviews.length) {
+                            console.warn('⚠️ sizeFit 필터링이 백엔드에서 제대로 되지 않았습니다!');
+                            console.log('조건에 맞지 않는 리뷰들:');
+                            reviews.filter(r => r.sizeFit !== queryParams.sizeFit).forEach(r => {
+                                console.log(`  - 리뷰 ${r.reviewId}: sizeFit=${r.sizeFit} (예상: ${queryParams.sizeFit})`);
+                            });
+                        }
+                    }
+                    
+                    if (queryParams.cushion) {
+                        const matchingReviews = reviews.filter(r => r.cushion === queryParams.cushion);
+                        console.log(`🔍 cushion="${queryParams.cushion}" 조건에 맞는 리뷰: ${matchingReviews.length}/${reviews.length}개`);
+                    }
+                    
+                    if (queryParams.stability) {
+                        const matchingReviews = reviews.filter(r => r.stability === queryParams.stability);
+                        console.log(`🔍 stability="${queryParams.stability}" 조건에 맞는 리뷰: ${matchingReviews.length}/${reviews.length}개`);
+                    }
+                } else {
+                    console.warn('⚠️ API 응답에서 content 배열을 찾을 수 없습니다.');
+                }
             }
             return response.data.data;
 
@@ -77,11 +183,13 @@ export class ReviewService {
                     console.warn('백엔드 연결 실패, 빈 데이터 반환');
                 }
                 return {
-                    content: [],
+                    reviews: [],
                     totalPages: 0,
                     totalElements: 0,
                     size: params.size || 10,
                     number: params.page || 0,
+                    averageRating: 0,
+                    totalReviews: 0,
                     first: true,
                     last: true
                 };
@@ -222,13 +330,16 @@ export class ReviewService {
             formData.append('content', reviewData.content);
             
             if (reviewData.sizeFit !== undefined) {
-                formData.append('sizeFit', reviewData.sizeFit.toString());
+                const sizeFitEnum = SCORE_TO_ENUM.sizeFit[reviewData.sizeFit as keyof typeof SCORE_TO_ENUM.sizeFit];
+                formData.append('sizeFit', sizeFitEnum);
             }
             if (reviewData.cushion !== undefined) {
-                formData.append('cushion', reviewData.cushion.toString());
+                const cushionEnum = SCORE_TO_ENUM.cushion[reviewData.cushion as keyof typeof SCORE_TO_ENUM.cushion];
+                formData.append('cushion', cushionEnum);
             }
             if (reviewData.stability !== undefined) {
-                formData.append('stability', reviewData.stability.toString());
+                const stabilityEnum = SCORE_TO_ENUM.stability[reviewData.stability as keyof typeof SCORE_TO_ENUM.stability];
+                formData.append('stability', stabilityEnum);
             }
 
             if (images && images.length > 0) {
@@ -327,7 +438,22 @@ export class ReviewService {
             }
 
             const formData = new FormData();
-            formData.append('review', JSON.stringify(reviewData));
+            
+            // 3요소 평가 값을 enum으로 변환
+            const convertedReviewData = {
+                ...reviewData,
+                ...(reviewData.sizeFit !== undefined && {
+                    sizeFit: SCORE_TO_ENUM.sizeFit[reviewData.sizeFit as keyof typeof SCORE_TO_ENUM.sizeFit]
+                }),
+                ...(reviewData.cushion !== undefined && {
+                    cushion: SCORE_TO_ENUM.cushion[reviewData.cushion as keyof typeof SCORE_TO_ENUM.cushion]
+                }),
+                ...(reviewData.stability !== undefined && {
+                    stability: SCORE_TO_ENUM.stability[reviewData.stability as keyof typeof SCORE_TO_ENUM.stability]
+                })
+            };
+            
+            formData.append('review', JSON.stringify(convertedReviewData));
 
             if (newImages && newImages.length > 0) {
                 newImages.forEach(image => {
@@ -524,6 +650,87 @@ export class ReviewService {
             if (process.env.NODE_ENV === 'development') {
                 console.error('내 리뷰 목록 조회 실패:', error);
             }
+            throw error;
+        }
+    }
+
+    // ===== 3요소 통계 관련 메서드 =====
+
+    /**
+     * 상품별 3요소 평가 통계 조회
+     * @param productId 상품 ID
+     * @returns 3요소 평가 통계 데이터
+     */
+    static async getProductStatistics(productId: number): Promise<any> {
+        try {
+            if (process.env.NODE_ENV === 'development') {
+                console.log('3요소 통계 API 호출:', productId);
+            }
+
+            const response = await axiosInstance.get<ApiResponse<any>>(
+                `/api/reviews/products/${productId}/statistics`
+            );
+
+            if (process.env.NODE_ENV === 'development') {
+                console.log('3요소 통계 API 응답:', response.data);
+                const stats = response.data.data;
+                
+                console.log('📊 쿠션감 통계 상세:', {
+                    distribution: stats.cushionStatistics?.distribution,
+                    percentage: stats.cushionStatistics?.percentage,
+                    mostSelected: stats.cushionStatistics?.mostSelected,
+                    averageScore: stats.cushionStatistics?.averageScore
+                });
+                
+                console.log('📊 착용감 통계 상세:', {
+                    distribution: stats.sizeFitStatistics?.distribution,
+                    percentage: stats.sizeFitStatistics?.percentage,
+                    mostSelected: stats.sizeFitStatistics?.mostSelected,
+                    averageScore: stats.sizeFitStatistics?.averageScore
+                });
+                
+                console.log('📊 안정성 통계 상세:', {
+                    distribution: stats.stabilityStatistics?.distribution,
+                    percentage: stats.stabilityStatistics?.percentage,
+                    mostSelected: stats.stabilityStatistics?.mostSelected,
+                    averageScore: stats.stabilityStatistics?.averageScore
+                });
+            }
+            return response.data.data;
+
+        } catch (error: any) {
+            if (process.env.NODE_ENV === 'development') {
+                console.error('3요소 통계 조회 실패:', error);
+            }
+
+            // 네트워크 오류나 서버 오류 시 빈 응답 반환
+            if (!error.response || error.code === 'NETWORK_ERROR') {
+                if (process.env.NODE_ENV === 'development') {
+                    console.warn('백엔드 연결 실패, 빈 통계 데이터 반환');
+                }
+                return {
+                    totalReviews: 0,
+                    cushionStatistics: {
+                        distribution: {},
+                        percentage: {},
+                        mostSelected: null,
+                        averageScore: 0.0
+                    },
+                    sizeFitStatistics: {
+                        distribution: {},
+                        percentage: {},
+                        mostSelected: null,
+                        averageScore: 0.0
+                    },
+                    stabilityStatistics: {
+                        distribution: {},
+                        percentage: {},
+                        mostSelected: null,
+                        averageScore: 0.0
+                    }
+                };
+            }
+
             throw error;
         }
     }

--- a/src/components/modal/ReviewSuccessModal.tsx
+++ b/src/components/modal/ReviewSuccessModal.tsx
@@ -1,0 +1,344 @@
+/**
+ * 리뷰 작성 성공 모달
+ * 
+ * 리뷰 작성 완료 시 표시되는 모달로 적립된 포인트 정보를 보여줍니다.
+ */
+
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import styled, { keyframes } from 'styled-components';
+import { CreateReviewResponse } from '../../types/review';
+
+// =============== 애니메이션 정의 ===============
+
+const slideInUp = keyframes`
+    from {
+        opacity: 0;
+        transform: translateY(30px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+`;
+
+const confetti = keyframes`
+    0% {
+        opacity: 1;
+        transform: translateY(0) rotate(0deg);
+    }
+    100% {
+        opacity: 0;
+        transform: translateY(-100px) rotate(360deg);
+    }
+`;
+
+const bounce = keyframes`
+    0%, 20%, 50%, 80%, 100% {
+        transform: translateY(0);
+    }
+    40% {
+        transform: translateY(-10px);
+    }
+    60% {
+        transform: translateY(-5px);
+    }
+`;
+
+const shine = keyframes`
+    0% {
+        background-position: -200% 0;
+    }
+    100% {
+        background-position: 200% 0;
+    }
+`;
+
+// =============== 스타일 컴포넌트 ===============
+
+const ModalOverlay = styled.div`
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    padding: 20px;
+    backdrop-filter: blur(4px);
+`;
+
+const ModalContent = styled.div`
+    background: white;
+    border-radius: 16px;
+    padding: 32px;
+    width: 100%;
+    max-width: 480px;
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+    animation: ${slideInUp} 0.3s ease-out;
+    position: relative;
+    overflow: hidden;
+
+    @media (max-width: 768px) {
+        padding: 24px;
+        margin: 0 16px;
+    }
+`;
+
+const SuccessHeader = styled.div`
+    text-align: center;
+    margin-bottom: 24px;
+`;
+
+const SuccessIcon = styled.div`
+    font-size: 48px;
+    margin-bottom: 16px;
+    animation: ${bounce} 2s ease-in-out infinite;
+`;
+
+const SuccessTitle = styled.h3`
+    font-size: 24px;
+    font-weight: 700;
+    color: #059669;
+    margin: 0 0 8px 0;
+
+    @media (max-width: 768px) {
+        font-size: 20px;
+    }
+`;
+
+const SuccessMessage = styled.p`
+    font-size: 16px;
+    color: #6b7280;
+    margin: 0;
+    line-height: 1.5;
+`;
+
+const PointReward = styled.div`
+    background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
+    border: 2px solid #f59e0b;
+    border-radius: 12px;
+    padding: 20px;
+    margin: 20px 0;
+    text-align: center;
+    position: relative;
+    overflow: hidden;
+
+    &::before {
+        content: '';
+        position: absolute;
+        top: -50%;
+        left: -50%;
+        width: 200%;
+        height: 200%;
+        background: linear-gradient(
+            45deg,
+            transparent,
+            rgba(255, 255, 255, 0.3),
+            transparent
+        );
+        animation: ${shine} 2s linear infinite;
+    }
+
+    @media (max-width: 768px) {
+        padding: 16px;
+    }
+`;
+
+const ConfettiParticle = styled.div<{ delay: number }>`
+    position: absolute;
+    top: -10px;
+    font-size: 16px;
+    animation: ${confetti} 3s linear infinite;
+    animation-delay: ${props => props.delay}s;
+
+    &:nth-child(1) { left: 10%; }
+    &:nth-child(2) { left: 20%; }
+    &:nth-child(3) { left: 30%; }
+    &:nth-child(4) { left: 70%; }
+    &:nth-child(5) { left: 80%; }
+    &:nth-child(6) { left: 90%; }
+`;
+
+const PointIcon = styled.div`
+    font-size: 32px;
+    margin-bottom: 8px;
+    display: inline-block;
+    animation: ${bounce} 1.5s ease-in-out infinite;
+`;
+
+const PointAmount = styled.div`
+    font-size: 24px;
+    font-weight: 800;
+    color: #d97706;
+    margin-bottom: 8px;
+
+    @media (max-width: 768px) {
+        font-size: 20px;
+    }
+`;
+
+const CurrentPoints = styled.p`
+    font-size: 14px;
+    color: #92400e;
+    margin: 0;
+    font-weight: 500;
+
+    strong {
+        font-weight: 700;
+        font-size: 16px;
+    }
+`;
+
+const PointFailed = styled.div`
+    background: #f3f4f6;
+    border: 2px solid #d1d5db;
+    border-radius: 12px;
+    padding: 20px;
+    margin: 20px 0;
+    text-align: center;
+
+    @media (max-width: 768px) {
+        padding: 16px;
+    }
+`;
+
+const FailedMessage = styled.p`
+    font-size: 14px;
+    color: #6b7280;
+    margin: 0;
+    line-height: 1.5;
+`;
+
+const ModalActions = styled.div`
+    display: flex;
+    gap: 12px;
+    margin-top: 24px;
+
+    @media (max-width: 768px) {
+        flex-direction: column;
+    }
+`;
+
+const ActionButton = styled.button<{ variant: 'primary' | 'secondary' }>`
+    flex: 1;
+    padding: 12px 20px;
+    border-radius: 10px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    border: none;
+
+    ${props => props.variant === 'primary' ? `
+        background: linear-gradient(135deg, #2563eb, #1d4ed8);
+        color: white;
+        
+        &:hover {
+            background: linear-gradient(135deg, #1d4ed8, #1e40af);
+            transform: translateY(-1px);
+            box-shadow: 0 4px 12px rgba(37, 99, 235, 0.4);
+        }
+    ` : `
+        background: white;
+        color: #374151;
+        border: 2px solid #e5e7eb;
+        
+        &:hover {
+            background: #f9fafb;
+            border-color: #d1d5db;
+        }
+    `}
+
+    &:focus {
+        outline: none;
+        box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+    }
+`;
+
+// =============== Props 타입 정의 ===============
+
+interface ReviewSuccessModalProps {
+    response: CreateReviewResponse;
+    onClose: () => void;
+}
+
+// =============== 메인 컴포넌트 ===============
+
+export const ReviewSuccessModal: React.FC<ReviewSuccessModalProps> = ({
+    response,
+    onClose
+}) => {
+    const navigate = useNavigate();
+    const { reviewId, pointsEarned, currentPoints } = response;
+
+    const handleMyReviewsClick = () => {
+        onClose();
+        navigate('/mypage/reviews');
+    };
+
+    const handleCloseClick = () => {
+        onClose();
+    };
+
+    return (
+        <ModalOverlay onClick={handleCloseClick}>
+            <ModalContent onClick={(e) => e.stopPropagation()}>
+                {/* 성공 헤더 */}
+                <SuccessHeader>
+                    <SuccessIcon>🎉</SuccessIcon>
+                    <SuccessTitle>리뷰 작성 완료!</SuccessTitle>
+                    <SuccessMessage>
+                        소중한 후기를 남겨주셔서 감사합니다.
+                    </SuccessMessage>
+                </SuccessHeader>
+
+                {/* 포인트 적립 결과 */}
+                {pointsEarned && pointsEarned > 0 ? (
+                    <PointReward>
+                        {/* 축하 색종이 */}
+                        {[0, 0.2, 0.4, 0.6, 0.8, 1.0].map((delay, index) => (
+                            <ConfettiParticle key={index} delay={delay}>
+                                🎊
+                            </ConfettiParticle>
+                        ))}
+                        
+                        <PointIcon>🪙</PointIcon>
+                        <PointAmount>+{pointsEarned}P 적립완료!</PointAmount>
+                        <CurrentPoints>
+                            현재 보유 포인트: <strong>{currentPoints?.toLocaleString()}P</strong>
+                        </CurrentPoints>
+                    </PointReward>
+                ) : (
+                    <PointFailed>
+                        <FailedMessage>
+                            포인트 적립은 일시적으로 지연될 수 있습니다.<br />
+                            마이페이지에서 포인트 적립 현황을 확인해주세요.
+                        </FailedMessage>
+                    </PointFailed>
+                )}
+
+                {/* 액션 버튼 */}
+                <ModalActions>
+                    <ActionButton
+                        variant="secondary"
+                        onClick={handleMyReviewsClick}
+                    >
+                        내 리뷰 보기
+                    </ActionButton>
+                    <ActionButton
+                        variant="primary"
+                        onClick={handleCloseClick}
+                    >
+                        확인
+                    </ActionButton>
+                </ModalActions>
+            </ModalContent>
+        </ModalOverlay>
+    );
+};
+
+export default ReviewSuccessModal;

--- a/src/components/review/ProductReviews.tsx
+++ b/src/components/review/ProductReviews.tsx
@@ -376,11 +376,14 @@ export const ProductReviews: React.FC<ProductReviewsProps> = ({
         ...(currentFilter.stability && currentFilter.stability > 0 && { stability: currentFilter.stability }),
       };
 
+      if (process.env.NODE_ENV === 'development') {
+        console.log('📦 ProductReviews - loadReviews 시작:', { productId, page, resetList, params });
+      }
+
       const response = await ReviewService.getProductReviews(productId, params);
       
       // API 응답에서 실제 리뷰 배열을 찾아서 사용
-      const responseData = response as any;
-      let reviewsData = responseData.reviews || response.content || [];
+      let reviewsData = response.reviews || [];
       
       // 🔧 프론트엔드에서 추가 필터링 (백엔드 필터링이 제대로 안될 경우 대비)
       if (currentFilter.rating && currentFilter.rating > 0) {
@@ -396,42 +399,82 @@ export const ProductReviews: React.FC<ProductReviewsProps> = ({
         console.log(`🔍 평점 필터링 적용: ${currentFilter.exactRating ? '정확히' : '이상'} ${currentFilter.rating}점, 결과: ${reviewsData.length}개`);
       }
       
-      // 3요소 필터링도 추가 적용
+      // 3요소 필터링도 추가 적용 (5단계 시스템)
       if (currentFilter.sizeFit && currentFilter.sizeFit > 0) {
         reviewsData = reviewsData.filter((review: Review) => {
+          // 백엔드에서 온 string enum을 숫자로 변환
           const sizeFit = typeof review.sizeFit === 'string' ? 
-            (review.sizeFit === 'SMALL' ? 1 : review.sizeFit === 'NORMAL' ? 2 : 3) : 
+            (review.sizeFit === 'VERY_SMALL' ? 1 : 
+             review.sizeFit === 'SMALL' ? 2 : 
+             review.sizeFit === 'NORMAL' ? 3 : 
+             review.sizeFit === 'BIG' ? 4 : 
+             review.sizeFit === 'VERY_BIG' ? 5 : 0) : 
             review.sizeFit;
-          return sizeFit === currentFilter.sizeFit;
+          const match = sizeFit === currentFilter.sizeFit;
+          if (process.env.NODE_ENV === 'development') {
+            console.log(`🔍 sizeFit 필터링: 리뷰(${review.reviewId}) ${review.sizeFit}(${sizeFit}) vs 조건(${currentFilter.sizeFit}) → ${match ? '✅' : '❌'}`);
+          }
+          return match;
         });
       }
       
       if (currentFilter.cushion && currentFilter.cushion > 0) {
         reviewsData = reviewsData.filter((review: Review) => {
           const cushion = typeof review.cushion === 'string' ? 
-            (review.cushion === 'SOFT' ? 1 : review.cushion === 'NORMAL' ? 2 : 3) : 
+            (review.cushion === 'VERY_FIRM' ? 1 : 
+             review.cushion === 'FIRM' ? 2 : 
+             review.cushion === 'MEDIUM' ? 3 : 
+             review.cushion === 'SOFT' ? 4 : 
+             review.cushion === 'VERY_SOFT' ? 5 : 0) : 
             review.cushion;
-          return cushion === currentFilter.cushion;
+          const match = cushion === currentFilter.cushion;
+          if (process.env.NODE_ENV === 'development') {
+            console.log(`🔍 cushion 필터링: 리뷰(${review.reviewId}) ${review.cushion}(${cushion}) vs 조건(${currentFilter.cushion}) → ${match ? '✅' : '❌'}`);
+          }
+          return match;
         });
       }
       
       if (currentFilter.stability && currentFilter.stability > 0) {
         reviewsData = reviewsData.filter((review: Review) => {
           const stability = typeof review.stability === 'string' ? 
-            (review.stability === 'LOW' ? 1 : review.stability === 'NORMAL' ? 2 : 3) : 
+            (review.stability === 'VERY_UNSTABLE' ? 1 : 
+             review.stability === 'UNSTABLE' ? 2 : 
+             review.stability === 'NORMAL' ? 3 : 
+             review.stability === 'STABLE' ? 4 : 
+             review.stability === 'VERY_STABLE' ? 5 : 0) : 
             review.stability;
-          return stability === currentFilter.stability;
+          const match = stability === currentFilter.stability;
+          if (process.env.NODE_ENV === 'development') {
+            console.log(`🔍 stability 필터링: 리뷰(${review.reviewId}) ${review.stability}(${stability}) vs 조건(${currentFilter.stability}) → ${match ? '✅' : '❌'}`);
+          }
+          return match;
         });
       }
       
-      if (reviewsData.length > 0) {
-        console.log(`📄 리뷰 ${reviewsData.length}개 로드됨`);
+      if (process.env.NODE_ENV === 'development') {
+        console.log(`📄 ProductReviews - 최종 리뷰 ${reviewsData.length}개, resetList: ${resetList}`);
+        console.log(`📋 최종 리뷰 목록:`, reviewsData.map(r => ({
+          id: r.reviewId, 
+          sizeFit: r.sizeFit,
+          cushion: r.cushion,
+          stability: r.stability
+        })));
       }
 
       if (resetList || page === 0) {
         setReviews(reviewsData); // 안전한 설정
+        if (process.env.NODE_ENV === 'development') {
+          console.log(`📦 ProductReviews - 새 리뷰 목록 설정: ${reviewsData.length}개`);
+        }
       } else {
-        setReviews(prev => [...(prev || []), ...reviewsData]); // 안전한 추가
+        setReviews(prev => {
+          const newList = [...(prev || []), ...reviewsData];
+          if (process.env.NODE_ENV === 'development') {
+            console.log(`📦 ProductReviews - 리뷰 목록 추가: ${prev?.length || 0} + ${reviewsData.length} = ${newList.length}`);
+          }
+          return newList;
+        });
       }
 
       setCurrentPage(response.number || 0);
@@ -722,16 +765,13 @@ export const ProductReviews: React.FC<ProductReviewsProps> = ({
             const response = await ReviewService.getProductReviews(productId, params);
             console.log('🔍 새로고침 후 리뷰 목록 응답:', response);
             
-            // 타입 안전성을 위해 any로 캐스팅
-            const responseData = response as any;
-            console.log('🔍 받은 리뷰 개수 (content):', response.content?.length || 0);
-            console.log('🔍 받은 리뷰 개수 (reviews):', responseData.reviews?.length || 0);
+            // 리뷰 데이터 로깅
+            console.log('🔍 받은 리뷰 개수 (reviews):', response.reviews?.length || 0);
             console.log('🔍 전체 리뷰 개수:', response.totalElements);
-            console.log('🔍 리뷰 목록 내용 (content):', response.content);
-            console.log('🔍 리뷰 목록 내용 (reviews):', responseData.reviews);
+            console.log('🔍 리뷰 목록 내용 (reviews):', response.reviews);
             
             // API 응답에서 실제 리뷰 배열을 찾아서 설정
-            let reviewsData = responseData.reviews || response.content || [];
+            let reviewsData = response.reviews || [];
             
             // 🔧 프론트엔드에서 추가 필터링 적용 (localStorage 새로고침시에도)
             if (filter.rating && filter.rating > 0) {

--- a/src/components/review/ProductStatistics.tsx
+++ b/src/components/review/ProductStatistics.tsx
@@ -1,0 +1,198 @@
+import React from 'react';
+import styled from 'styled-components';
+import { ProductStatistics as ProductStatisticsType, ElementStatistics, ELEMENT_LABELS, ELEMENT_OPTIONS } from '../../types/review';
+
+const StatisticsContainer = styled.div`
+  margin: 2rem 0;
+  padding: 1.5rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  background-color: #fafafa;
+`;
+
+const Title = styled.h3`
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+  color: #333;
+`;
+
+const ElementContainer = styled.div`
+  margin-bottom: 2rem;
+  
+  &:last-child {
+    margin-bottom: 0;
+  }
+`;
+
+const ElementTitle = styled.h4`
+  font-size: 1rem;
+  font-weight: 500;
+  margin-bottom: 1rem;
+  color: #555;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+`;
+
+const AverageScore = styled.span`
+  background-color: #007bff;
+  color: white;
+  padding: 0.2rem 0.5rem;
+  border-radius: 12px;
+  font-size: 0.8rem;
+  font-weight: 600;
+`;
+
+const DistributionContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+`;
+
+const DistributionItem = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+`;
+
+const Label = styled.span`
+  min-width: 100px;
+  font-size: 0.9rem;
+  color: #666;
+`;
+
+const BarContainer = styled.div`
+  flex: 1;
+  height: 24px;
+  background-color: #e9ecef;
+  border-radius: 12px;
+  overflow: hidden;
+  position: relative;
+`;
+
+const Bar = styled.div<{ percentage: number; isSelected: boolean }>`
+  height: 100%;
+  background-color: ${props => props.isSelected ? '#28a745' : '#007bff'};
+  width: ${props => props.percentage}%;
+  border-radius: 12px;
+  transition: all 0.3s ease;
+`;
+
+const Percentage = styled.span`
+  min-width: 45px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #333;
+  text-align: right;
+`;
+
+const Count = styled.span`
+  min-width: 35px;
+  font-size: 0.8rem;
+  color: #666;
+  text-align: right;
+`;
+
+const EmptyState = styled.div`
+  text-align: center;
+  padding: 2rem;
+  color: #666;
+  font-size: 0.9rem;
+`;
+
+interface Props {
+  statistics: ProductStatisticsType;
+  loading?: boolean;
+}
+
+const ProductStatistics: React.FC<Props> = ({ statistics, loading = false }) => {
+  if (loading) {
+    return (
+      <StatisticsContainer>
+        <Title>3요소 평가 통계</Title>
+        <EmptyState>통계를 불러오는 중...</EmptyState>
+      </StatisticsContainer>
+    );
+  }
+
+  if (statistics.totalReviews === 0) {
+    return (
+      <StatisticsContainer>
+        <Title>3요소 평가 통계</Title>
+        <EmptyState>아직 리뷰가 없어 통계를 표시할 수 없습니다.</EmptyState>
+      </StatisticsContainer>
+    );
+  }
+
+  const renderElementStatistics = (
+    title: string,
+    elementStats: ElementStatistics,
+    labelMap: Record<string, string>
+  ) => {
+    // 요소 타입 식별
+    const elementType = elementStats === statistics.cushionStatistics ? 'cushion' :
+                       elementStats === statistics.sizeFitStatistics ? 'sizeFit' : 'stability';
+    
+    // 우리가 정의한 순서대로 정렬
+    const entries = ELEMENT_OPTIONS[elementType as keyof typeof ELEMENT_OPTIONS]
+      .map(option => [option.enum, elementStats.distribution[option.enum] || 0] as [string, number])
+      .filter(([_, count]) => count > 0);
+
+    if (entries.length === 0) {
+      return null;
+    }
+
+    return (
+      <ElementContainer key={title}>
+        <ElementTitle>
+          {title}
+          <AverageScore>{elementStats.averageScore.toFixed(1)}점</AverageScore>
+        </ElementTitle>
+        <DistributionContainer>
+          {entries.map(([level, count]) => {
+            const percentage = elementStats.percentage[level] || 0;
+            const isSelected = level === elementStats.mostSelected;
+            
+            return (
+              <DistributionItem key={level}>
+                <Label>{labelMap[level] || level}</Label>
+                <BarContainer>
+                  <Bar percentage={percentage} isSelected={isSelected} />
+                </BarContainer>
+                <Percentage>{percentage.toFixed(1)}%</Percentage>
+                <Count>({count})</Count>
+              </DistributionItem>
+            );
+          })}
+        </DistributionContainer>
+      </ElementContainer>
+    );
+  };
+
+  return (
+    <StatisticsContainer>
+      <Title>3요소 평가 통계 (총 {statistics.totalReviews}개 리뷰 기준)</Title>
+      
+      {renderElementStatistics(
+        '쿠션감',
+        statistics.cushionStatistics,
+        ELEMENT_LABELS.cushion
+      )}
+      
+      {renderElementStatistics(
+        '착용감',
+        statistics.sizeFitStatistics,
+        ELEMENT_LABELS.sizeFit
+      )}
+      
+      {renderElementStatistics(
+        '안정성',
+        statistics.stabilityStatistics,
+        ELEMENT_LABELS.stability
+      )}
+    </StatisticsContainer>
+  );
+};
+
+export default ProductStatistics;

--- a/src/components/review/ProductStatisticsChart.tsx
+++ b/src/components/review/ProductStatisticsChart.tsx
@@ -1,0 +1,313 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { ProductStatistics as ProductStatisticsType, ElementStatistics, ELEMENT_LABELS, ELEMENT_OPTIONS } from '../../types/review';
+
+const StatisticsContainer = styled.div`
+  margin: 2rem 0;
+  padding: 1.5rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  background-color: #fafafa;
+`;
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+`;
+
+const Title = styled.h3`
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #333;
+  margin: 0;
+`;
+
+
+const ChartContainer = styled.div`
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+  
+  @media (max-width: 768px) {
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+`;
+
+const ElementChart = styled.div`
+  flex: 1;
+  min-width: 280px;
+  padding: 1rem;
+  background-color: white;
+  border-radius: 8px;
+  border: 1px solid #e9ecef;
+`;
+
+const ElementTitle = styled.h4`
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: #333;
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+`;
+
+const AverageScore = styled.span`
+  background-color: #007bff;
+  color: white;
+  padding: 0.2rem 0.6rem;
+  border-radius: 12px;
+  font-size: 0.8rem;
+  font-weight: 600;
+`;
+
+const ChartArea = styled.div`
+  height: 200px;
+  display: flex;
+  align-items: end;
+  gap: 8px;
+  padding: 1rem 0.5rem 0.5rem;
+  border-bottom: 2px solid #dee2e6;
+  border-left: 2px solid #dee2e6;
+  position: relative;
+`;
+
+const Bar = styled.div<{ height: number; isSelected: boolean; color: string; isEmpty: boolean }>`
+  flex: 1;
+  background: ${props => props.isEmpty 
+    ? `linear-gradient(to top, ${props.color}22, ${props.color}11)` 
+    : `linear-gradient(to top, ${props.color}, ${props.color}cc)`
+  };
+  height: ${props => props.height}%;
+  min-height: 4px;
+  border-radius: 4px 4px 0 0;
+  position: relative;
+  transition: all 0.3s ease;
+  border: ${props => props.isSelected ? '2px solid #ffc107' : '1px solid rgba(255,255,255,0.3)'};
+  box-shadow: ${props => props.isSelected ? '0 4px 8px rgba(255,193,7,0.3)' : '0 2px 4px rgba(0,0,0,0.1)'};
+  opacity: ${props => props.isEmpty ? 0.4 : 1};
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  }
+`;
+
+const BarValue = styled.div`
+  position: absolute;
+  top: -25px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #333;
+  background-color: rgba(255,255,255,0.9);
+  padding: 2px 6px;
+  border-radius: 4px;
+  white-space: nowrap;
+`;
+
+const BarLabels = styled.div`
+  display: flex;
+  gap: 8px;
+  margin-top: 0.5rem;
+`;
+
+const BarLabel = styled.div`
+  flex: 1;
+  text-align: center;
+  font-size: 0.7rem;
+  color: #666;
+  line-height: 1.2;
+  word-break: keep-all;
+`;
+
+const EmptyState = styled.div`
+  text-align: center;
+  padding: 2rem;
+  color: #666;
+  font-size: 0.9rem;
+`;
+
+const Summary = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  margin-top: 1rem;
+  padding: 1rem;
+  background-color: #f8f9fa;
+  border-radius: 6px;
+  
+  @media (max-width: 768px) {
+    flex-direction: column;
+    gap: 1rem;
+  }
+`;
+
+const SummaryItem = styled.div`
+  text-align: center;
+`;
+
+const SummaryLabel = styled.div`
+  font-size: 0.8rem;
+  color: #666;
+  margin-bottom: 0.25rem;
+`;
+
+const SummaryValue = styled.div`
+  font-size: 1rem;
+  font-weight: 600;
+  color: #333;
+`;
+
+interface Props {
+  statistics: ProductStatisticsType;
+  loading?: boolean;
+}
+
+const ProductStatisticsChart: React.FC<Props> = ({ statistics, loading = false }) => {
+
+  if (process.env.NODE_ENV === 'development') {
+    console.log('📈 ProductStatisticsChart 받은 데이터:', {
+      totalReviews: statistics.totalReviews,
+      cushion: {
+        averageScore: statistics.cushionStatistics?.averageScore,
+        distribution: statistics.cushionStatistics?.distribution,
+        mostSelected: statistics.cushionStatistics?.mostSelected
+      },
+      sizeFit: {
+        averageScore: statistics.sizeFitStatistics?.averageScore,
+        distribution: statistics.sizeFitStatistics?.distribution,
+        mostSelected: statistics.sizeFitStatistics?.mostSelected
+      },
+      stability: {
+        averageScore: statistics.stabilityStatistics?.averageScore,
+        distribution: statistics.stabilityStatistics?.distribution,
+        mostSelected: statistics.stabilityStatistics?.mostSelected
+      }
+    });
+  }
+
+  if (loading) {
+    return (
+      <StatisticsContainer>
+        <Header>
+          <Title>3요소 평가 통계</Title>
+        </Header>
+        <EmptyState>통계를 불러오는 중...</EmptyState>
+      </StatisticsContainer>
+    );
+  }
+
+  if (statistics.totalReviews === 0) {
+    return (
+      <StatisticsContainer>
+        <Header>
+          <Title>3요소 평가 통계</Title>
+        </Header>
+        <EmptyState>아직 리뷰가 없어 통계를 표시할 수 없습니다.</EmptyState>
+      </StatisticsContainer>
+    );
+  }
+
+  const getColorForElement = (elementType: string, index: number, isSelected: boolean) => {
+    const colors = {
+      cushion: ['#ff6b6b', '#ff8e8e', '#ffb1b1', '#ffd4d4', '#ffe7e7'],
+      sizeFit: ['#4ecdc4', '#6ed4cc', '#8edcd4', '#aee4dc', '#ceece4'],
+      stability: ['#45b7d1', '#66c5d9', '#87d3e1', '#a8e1e9', '#c9eff1']
+    };
+    
+    const elementColors = colors[elementType as keyof typeof colors] || colors.cushion;
+    return isSelected ? '#ffc107' : elementColors[index % elementColors.length];
+  };
+
+  const renderBarChart = (
+    title: string,
+    elementType: string,
+    elementStats: ElementStatistics,
+    labelMap: Record<string, string>
+  ) => {
+    // 5가지 평가를 모두 표시 (데이터가 없어도 0으로 표시)
+    const entries = ELEMENT_OPTIONS[elementType as keyof typeof ELEMENT_OPTIONS]
+      .map(option => [option.enum, elementStats.distribution[option.enum] || 0] as [string, number]);
+
+    const maxCount = Math.max(...entries.map(([_, count]) => count), 1); // 최소값 1로 설정해서 빈 차트 방지
+
+    return (
+      <ElementChart key={title}>
+        <ElementTitle>
+          {title}
+          <AverageScore>{elementStats.averageScore.toFixed(1)}점</AverageScore>
+        </ElementTitle>
+        
+        <ChartArea>
+          {entries.map(([level, count], index) => {
+            const percentage = elementStats.percentage[level] || 0;
+            const height = Math.max((count / maxCount) * 100, 2); // 최소 2% 높이 보장
+            const isSelected = level === elementStats.mostSelected;
+            const color = getColorForElement(elementType, index, false);
+            
+            return (
+              <Bar 
+                key={level}
+                height={height}
+                isSelected={isSelected}
+                color={color}
+                isEmpty={count === 0}
+              >
+                <BarValue>
+                  {count > 0 ? `${count}개 (${percentage.toFixed(1)}%)` : '0개'}
+                </BarValue>
+              </Bar>
+            );
+          })}
+        </ChartArea>
+        
+        <BarLabels>
+          {entries.map(([level]) => (
+            <BarLabel key={level}>
+              {labelMap[level] || level}
+            </BarLabel>
+          ))}
+        </BarLabels>
+      </ElementChart>
+    );
+  };
+
+
+  return (
+    <StatisticsContainer>
+      <Header>
+        <Title>3요소 평가 통계 (총 {statistics.totalReviews}개 리뷰 기준)</Title>
+      </Header>
+
+      <ChartContainer>
+        {renderBarChart('쿠션감', 'cushion', statistics.cushionStatistics, ELEMENT_LABELS.cushion)}
+        {renderBarChart('착용감', 'sizeFit', statistics.sizeFitStatistics, ELEMENT_LABELS.sizeFit)}
+        {renderBarChart('안정성', 'stability', statistics.stabilityStatistics, ELEMENT_LABELS.stability)}
+      </ChartContainer>
+
+      <Summary>
+        <SummaryItem>
+          <SummaryLabel>쿠션감 평균</SummaryLabel>
+          <SummaryValue>{statistics.cushionStatistics.averageScore.toFixed(1)}점</SummaryValue>
+        </SummaryItem>
+        <SummaryItem>
+          <SummaryLabel>착용감 평균</SummaryLabel>
+          <SummaryValue>{statistics.sizeFitStatistics.averageScore.toFixed(1)}점</SummaryValue>
+        </SummaryItem>
+        <SummaryItem>
+          <SummaryLabel>안정성 평균</SummaryLabel>
+          <SummaryValue>{statistics.stabilityStatistics.averageScore.toFixed(1)}점</SummaryValue>
+        </SummaryItem>
+      </Summary>
+    </StatisticsContainer>
+  );
+};
+
+export default ProductStatisticsChart;

--- a/src/components/review/ReviewFilter.tsx
+++ b/src/components/review/ReviewFilter.tsx
@@ -8,7 +8,7 @@
 import React from "react";
 import styled from "styled-components";
 import { formatNumber } from "../../utils/review/reviewHelpers";
-import { ReviewSortOption, ReviewFilterState } from "../../types/review";
+import { ReviewSortOption, ReviewFilterState, ELEMENT_OPTIONS } from "../../types/review";
 
 // =============== 타입 정의 ===============
 
@@ -38,27 +38,21 @@ const RATING_OPTIONS = [
     { value: 1, label: '1점 이상', exactLabel: '1점' },
 ] as const;
 
-// 3요소 필터 옵션
+// 3요소 필터 옵션 (5단계 + 전체)
 const SIZE_FIT_OPTIONS = [
     { value: 0, label: '전체' },
-    { value: 1, label: '작음' },
-    { value: 2, label: '적당함' },
-    { value: 3, label: '큼' },
-] as const;
+    ...ELEMENT_OPTIONS.sizeFit,
+];
 
 const CUSHION_OPTIONS = [
     { value: 0, label: '전체' },
-    { value: 1, label: '부드러움' },
-    { value: 2, label: '적당함' },
-    { value: 3, label: '딱딱함' },
-] as const;
+    ...ELEMENT_OPTIONS.cushion,
+];
 
 const STABILITY_OPTIONS = [
     { value: 0, label: '전체' },
-    { value: 1, label: '낮음' },
-    { value: 2, label: '보통' },
-    { value: 3, label: '높음' },
-] as const;
+    ...ELEMENT_OPTIONS.stability,
+];
 
 // =============== 스타일 컴포넌트 ===============
 

--- a/src/components/review/ReviewList.tsx
+++ b/src/components/review/ReviewList.tsx
@@ -227,6 +227,18 @@ export const ReviewList: React.FC<ReviewListProps> = ({
                                                       }) => {
     const infiniteScrollRef = useRef<HTMLDivElement>(null);
 
+    // 컴포넌트 props 디버깅
+    if (process.env.NODE_ENV === 'development') {
+        console.log('🎯 ReviewList 컴포넌트 props:', {
+            reviewsLength: reviews?.length || 0,
+            reviewsArray: reviews,
+            isLoading,
+            hasMore,
+            error,
+            reviewIds: reviews?.map(r => r.reviewId) || []
+        });
+    }
+
     /**
      * 무한 스크롤 처리
      * Intersection Observer를 사용하여 화면 하단에 도달했을 때 자동으로 더 불러오기

--- a/src/hooks/review/useProductStatistics.ts
+++ b/src/hooks/review/useProductStatistics.ts
@@ -1,0 +1,76 @@
+import { useState, useEffect } from 'react';
+import { ReviewService } from '../../api/reviewService';
+import { ProductStatistics } from '../../types/review';
+
+interface UseProductStatisticsReturn {
+  statistics: ProductStatistics | null;
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export const useProductStatistics = (productId: number | undefined): UseProductStatisticsReturn => {
+  const [statistics, setStatistics] = useState<ProductStatistics | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchStatistics = async () => {
+    if (!productId) {
+      setStatistics(null);
+      setLoading(false);
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      const data = await ReviewService.getProductStatistics(productId);
+      setStatistics(data);
+
+    } catch (err: any) {
+      console.error('통계 조회 실패:', err);
+      setError(err.response?.data?.message || '통계를 불러오는데 실패했습니다.');
+      
+      // 에러 발생 시에도 빈 통계 데이터를 설정하여 UI가 깨지지 않도록 함
+      setStatistics({
+        totalReviews: 0,
+        cushionStatistics: {
+          distribution: {},
+          percentage: {},
+          mostSelected: null,
+          averageScore: 0.0
+        },
+        sizeFitStatistics: {
+          distribution: {},
+          percentage: {},
+          mostSelected: null,
+          averageScore: 0.0
+        },
+        stabilityStatistics: {
+          distribution: {},
+          percentage: {},
+          mostSelected: null,
+          averageScore: 0.0
+        }
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchStatistics();
+  }, [productId]);
+
+  const refetch = () => {
+    fetchStatistics();
+  };
+
+  return {
+    statistics,
+    loading,
+    error,
+    refetch
+  };
+};

--- a/src/hooks/review/useReviewList.ts
+++ b/src/hooks/review/useReviewList.ts
@@ -80,6 +80,15 @@ export const useReviewList = (options: UseReviewListOptions): UseReviewListRetur
         resetList: boolean = false
     ) => {
         try {
+            if (process.env.NODE_ENV === 'development') {
+                console.log('📦 useReviewList - loadReviews 시작:', {
+                    productId,
+                    page,
+                    resetList,
+                    filter: JSON.stringify(filter)
+                });
+            }
+
             setIsLoading(true);
             setError(null);
 
@@ -106,16 +115,45 @@ export const useReviewList = (options: UseReviewListOptions): UseReviewListRetur
                 params.stability = filter.stability;
             }
 
+            if (process.env.NODE_ENV === 'development') {
+                console.log('📦 useReviewList - API 호출 직전');
+            }
+
             const response: ReviewListResponse = await ReviewService.getProductReviews(
                 productId,
                 params
             );
 
-            // 리뷰 목록 업데이트
+            if (process.env.NODE_ENV === 'development') {
+                console.log('📦 useReviewList - API 응답 받음:', response);
+            }
+
+            // 리뷰 목록 업데이트 (백엔드 응답 구조에 맞게 수정)
+            if (process.env.NODE_ENV === 'development') {
+                console.log('📦 useReviewList - 응답 데이터 구조:', {
+                    hasReviews: !!response.reviews,
+                    reviewsLength: response.reviews?.length,
+                    reviewsType: Array.isArray(response.reviews) ? 'array' : typeof response.reviews,
+                    firstReview: response.reviews?.[0],
+                    resetList,
+                    page
+                });
+            }
+
             if (resetList || page === 0) {
-                setReviews(response.content || []); // 안전한 설정
+                const newReviews = response.reviews || [];
+                setReviews(newReviews);
+                if (process.env.NODE_ENV === 'development') {
+                    console.log('📦 useReviewList - 새 리뷰 목록 설정:', newReviews.length, '개');
+                }
             } else {
-                setReviews(prev => [...prev, ...(response.content || [])]); // 안전한 추가
+                setReviews(prev => {
+                    const newReviews = [...prev, ...(response.reviews || [])];
+                    if (process.env.NODE_ENV === 'development') {
+                        console.log('📦 useReviewList - 리뷰 목록 추가:', prev.length, '+', (response.reviews || []).length, '=', newReviews.length);
+                    }
+                    return newReviews;
+                });
             }
 
             // 페이지네이션 정보 업데이트
@@ -123,6 +161,15 @@ export const useReviewList = (options: UseReviewListOptions): UseReviewListRetur
             setTotalPages(response.totalPages);
             setTotalCount(response.totalElements);
             setHasMore(!response.last);
+
+            if (process.env.NODE_ENV === 'development') {
+                console.log('📦 useReviewList - 페이지네이션 업데이트:', {
+                    currentPage: response.number,
+                    totalPages: response.totalPages,
+                    totalCount: response.totalElements,
+                    hasMore: !response.last
+                });
+            }
 
         } catch (err) {
             console.error('리뷰 목록 로딩 실패:', err);
@@ -188,7 +235,22 @@ export const useReviewList = (options: UseReviewListOptions): UseReviewListRetur
      * 필터 변경 시 리뷰 목록 새로고침
      */
     useEffect(() => {
+        if (process.env.NODE_ENV === 'development') {
+            console.log('📦 useReviewList - 필터 변경 감지:', {
+                productId,
+                'filter.sort': filter.sort,
+                'filter.rating': filter.rating,
+                'filter.exactRating': filter.exactRating,
+                'filter.sizeFit': filter.sizeFit,
+                'filter.cushion': filter.cushion,
+                'filter.stability': filter.stability
+            });
+        }
+
         if (productId > 0) {
+            if (process.env.NODE_ENV === 'development') {
+                console.log('📦 useReviewList - loadReviews 호출 (필터 변경)');
+            }
             loadReviews(0, true);
         }
     }, [filter.sort, filter.rating, filter.exactRating, filter.sizeFit, filter.cushion, filter.stability]); // loadReviews는 의존성에서 제외 (무한 루프 방지)

--- a/src/pages/products/DetailPage.tsx
+++ b/src/pages/products/DetailPage.tsx
@@ -7,6 +7,7 @@ import CartSuccessModal from "components/modal/CartSuccessModal"; // 장바구�
 import { useProductDetail } from "../../hooks/products/useProductDetail"; // 상품 상세 데이터 관리
 import { useProductOptions } from "../../hooks/products/useProductOptions"; // 옵션 선택 및 수량 관리
 import { useProductActions } from "../../hooks/products/useProductActions"; // 장바구니/주문 액션 관리
+import { useProductStatistics } from "../../hooks/review/useProductStatistics"; // 3요소 통계 훅
 // 상품 상세 UI 컴포넌트들
 import { ProductImages } from "../../components/products/ProductImages"; // 상품 이미지 슬라이더
 import { ProductInfo } from "../../components/products/ProductInfo"; // 상품 기본 정보 (이름, 가격 등)
@@ -14,6 +15,8 @@ import { ModernOptionSelector } from "../../components/products/ModernOptionSele
 import { SelectedOptions } from "../../components/products/SelectedOptions"; // 선택된 옵션 표시 및 수량 조절
 import { ProductDescription } from "../../components/products/ProductDescription"; // 상품 상세 설명
 import { ProductReviews } from "../../components/review/ProductReviews"; // 상품 리뷰 섹션
+import ProductStatistics from "../../components/review/ProductStatistics"; // 3요소 통계 컴포넌트
+import ProductStatisticsChart from "../../components/review/ProductStatisticsChart"; // 3요소 막대그래프 통계 컴포넌트
 // 유틸리티 함수들
 import {
   formatPrice, // 가격 포맷팅 (예: 50000 -> "50,000")
@@ -56,6 +59,9 @@ const DetailPage: React.FC = () => {
 
   // 상품 상세 정보 관리 훅
   const { product, loading, error } = useProductDetail(id);
+
+  // 3요소 통계 관리 훅
+  const { statistics, loading: statsLoading } = useProductStatistics(product?.productId);
 
   // 상품 옵션 선택 및 관리 훅
   const {
@@ -204,6 +210,14 @@ const DetailPage: React.FC = () => {
 
       {/* 상품 상세 설명 섹션 */}
       <ProductDescription product={product} />
+
+      {/* 3요소 평가 통계 섹션 */}
+      {statistics && (
+        <ProductStatisticsChart
+          statistics={statistics}
+          loading={statsLoading}
+        />
+      )}
 
       {/* 상품 리뷰 섹션 */}
       <ProductReviews

--- a/src/pages/reviews/ReviewWritePage.tsx
+++ b/src/pages/reviews/ReviewWritePage.tsx
@@ -13,7 +13,7 @@ import { useReviewActions } from "../../hooks/review/useReviewActions";
 import ReviewService from "../../api/reviewService";
 import { validateReviewTitle, validateReviewContent, validateRating, validateImages, getEvaluationLabel } from "../../utils/review/reviewHelpers";
 import { ReviewSuccessModal } from "../../components/modal/ReviewSuccessModal";
-import { CreateReviewResponse } from "../../types/review";
+import { CreateReviewResponse, ELEMENT_OPTIONS } from "../../types/review";
 
 // =============== 타입 정의 ===============
 
@@ -296,40 +296,59 @@ const CharacterCount = styled.div`
 `;
 
 const EvaluationGrid = styled.div`
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 16px;
-
-    @media (max-width: 768px) {
-        grid-template-columns: 1fr;
-        gap: 12px;
-    }
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
 `;
 
 const EvaluationItem = styled.div`
-    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+`;
+
+const EvaluationRow = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 16px;
+`;
+
+const EvaluationLabel = styled.div`
+    min-width: 80px;
+    font-size: 14px;
+    font-weight: 500;
+    color: #374151;
+    text-align: left;
 `;
 
 const EvaluationButtons = styled.div`
     display: flex;
     gap: 4px;
-    justify-content: center;
-    margin-top: 8px;
+    flex: 1;
 `;
 
 const EvaluationButton = styled.button<{ $active: boolean }>`
-    padding: 8px 12px;
+    flex: 1;
+    padding: 8px 4px;
     border: 1px solid ${props => props.$active ? '#2563eb' : '#d1d5db'};
     border-radius: 6px;
     background: ${props => props.$active ? '#2563eb' : 'white'};
     color: ${props => props.$active ? 'white' : '#374151'};
-    font-size: 12px;
+    font-size: 11px;
     cursor: pointer;
     transition: all 0.2s ease;
+    min-width: 0;
+    text-align: center;
+    line-height: 1.2;
 
     &:hover {
         border-color: #2563eb;
         background: ${props => props.$active ? '#1d4ed8' : '#eff6ff'};
+    }
+
+    @media (max-width: 768px) {
+        font-size: 10px;
+        padding: 6px 3px;
     }
 `;
 
@@ -798,21 +817,21 @@ export const ReviewWritePage: React.FC = () => {
                         <EvaluationGrid>
                             {(['sizeFit', 'cushion', 'stability'] as const).map(type => (
                                 <EvaluationItem key={type}>
-                                    <Label>{getEvaluationLabel(type)}</Label>
-                                    <EvaluationButtons>
-                                        {[1, 2, 3].map(value => (
-                                            <EvaluationButton
-                                                key={value}
-                                                type="button"
-                                                $active={formData[type] === value}
-                                                onClick={() => handleEvaluationChange(type, value)}
-                                            >
-                                                {type === 'sizeFit' && ['작음', '적당', '큼'][value - 1]}
-                                                {type === 'cushion' && ['부드러움', '적당', '딱딱함'][value - 1]}
-                                                {type === 'stability' && ['낮음', '보통', '높음'][value - 1]}
-                                            </EvaluationButton>
-                                        ))}
-                                    </EvaluationButtons>
+                                    <EvaluationRow>
+                                        <EvaluationLabel>{getEvaluationLabel(type)}</EvaluationLabel>
+                                        <EvaluationButtons>
+                                            {ELEMENT_OPTIONS[type].map(option => (
+                                                <EvaluationButton
+                                                    key={option.value}
+                                                    type="button"
+                                                    $active={formData[type] === option.value}
+                                                    onClick={() => handleEvaluationChange(type, option.value)}
+                                                >
+                                                    {option.label}
+                                                </EvaluationButton>
+                                            ))}
+                                        </EvaluationButtons>
+                                    </EvaluationRow>
                                 </EvaluationItem>
                             ))}
                         </EvaluationGrid>


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
<!--리뷰 목록에서 리뷰 작성자의 신체 정보(키, 몸무게, 발 사이즈, 발 너비)를 표시하는 기능 추가 -->


**Type**
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [x] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?

  - ReviewCard 컴포넌트에 사용자 신체 정보 표시 기능 추가
  - 리뷰 작성자의 키, 몸무게, 발 사이즈, 발 너비를 사용자 이름 아래에 태그 형태로 표시
  - UserProfileService를 활용하여 리뷰 작성자의 프로필 정보를 동적으로 로드
  - 발 너비 enum 값을 한국어로 변환하는 유틸리티 함수 추가

### 왜 필요했나요?

  - 신발/의류 리뷰를 볼 때 다른 사용자의 신체 정보를 참고하여 사이즈나 핏을 더 정확하게 판단할 수 있도록 함
  - 특히 온라인 쇼핑에서 사이즈 선택의 불확실성을 줄이고 구매 결정에 도움이 되는 정보 제공
  - 리뷰의 신뢰성과 유용성 향상

---

## 🔧 How (구현 방법)
### 주요 변경사항

  - src/components/review/ReviewCard.tsx: 신체 정보 표시 기능 추가
    - useEffect로 리뷰 작성자 프로필 정보 로드
    - UserBodyInfo, BodyInfoItem 스타일 컴포넌트 추가
    - 발 너비 텍스트 변환 함수 구현

### 기술적 접근

  - UserProfileService의 getUserProfileById API를 활용하여 사용자별 신체 정보 조회
  - 신체 정보가 있는 경우에만 표시하도록 조건부 렌더링 적용
  - 작은 회색 태그 형태로 깔끔하게 디자인하여 기존 UI와 조화
  - 발 너비 enum (NARROW/NORMAL/WIDE)을 한국어(좁음/보통/넓음)로 변환

---

## 🧪 Testing
### 테스트 방법

  - 다양한 사용자의 리뷰가 포함된 상품 상세 페이지에서 신체 정보 표시 확인
  - 신체 정보가 없는 사용자의 리뷰에서는 신체 정보 섹션이 표시되지 않음을 확인
  - 신체 정보 일부만 있는 경우 해당 정보만 표시됨을 확인

### 확인 사항
- [x] 기능 정상 동작 확인
- [x] 기존 기능 영향 없음
- [x] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 관련 이슈: #204 
- 지라 백로그: MYCE-296
---

## 💬 Additional Notes

  성능 개선 필요:
  현재 구현은 각 ReviewCard마다 UserProfileService.getUserProfileById()를 호출하는 방식입니다. 리뷰가 많을 경우 성능 이슈가 있을 수 있으므로, 향후 백엔드에서 리뷰 목록 API에       
  사용자 신체 정보를 포함하여 반환하도록 개선하는 것을 권장합니다. <- 개선 완료

  백엔드 연동 개선안:
  - 리뷰 목록 API 응답에 userHeight, userWeight, userFootSize, userFootWidth 필드 추가
  - Review 테이블과 User 테이블 조인을 통해 한 번의 쿼리로 모든 정보 조회

---

## ✅ Checklist
- [x] 코드 리뷰 준비 완료
- [x] 테스트 완료
- [x] 불필요한 로그 제거
